### PR TITLE
Adds missing redirect post for MCP specs update

### DIFF
--- a/_posts/2025-06-26-mcp-specs-update-all-about-auth.md
+++ b/_posts/2025-06-26-mcp-specs-update-all-about-auth.md
@@ -1,0 +1,25 @@
+---
+hidden: false
+date: 2025-06-26T04:00:00.000+00:00
+title: "Model Context Protocol (MCP) Spec Updates from June 2025: One Small Step for a Spec, One Giant Leap for Security"
+redirect_to:
+  - https://auth0.com/blog/mcp-specs-update-all-about-auth/
+image: "https://res.cloudinary.com/jesstemporal/image/upload/v1640360836/covers/pro_tip_voc9gk.png"
+lang: en
+type: post
+tags:
+- mcp
+- ai
+- auth
+- english
+- tutorial
+description: 'Explore the latest MCP specifications update focusing on authentication mechanisms and security improvements for AI assistants'
+author_note: false
+
+---
+
+Learn about the new classification of MCP servers as OAuth Resource Servers, implementing Resource Indicators to prevent token misuse, and the clearer security best practices designed to help you build more robust and secure MCP applications
+
+Click on the button below to continue reading 👇
+
+<br> <center> <a href="https://auth0.com/blog/mcp-specs-update-all-about-auth/"> <img src="/images/keep_reading.png"/> </a> </center>


### PR DESCRIPTION

* Added a new blog post (`_posts/2025-06-26-mcp-specs-update-all-about-auth.md`) summarizing the latest MCP specification updates, with a redirect to the full article on Auth0's blog.