### PR TITLE
Replace site email links with Notion contact forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ See [LICENCE.md](LICENCE.md).
 ## Contact
 
 - **Website**: [jtemporal.com](https://jtemporal.com)
-- **Email**: hello@jtemporal.com
+- **Contact form**: [English](https://jesstemporal.notion.site/27252b5614cf4a3cb75df604432a912e) · [Português](https://jesstemporal.notion.site/3919dd3e5b6c80f0bbf8de4876374909)
 - **Twitter**: [@jesstemporal](https://twitter.com/jesstemporal)
 - **GitHub**: [@jtemporal](https://github.com/jtemporal)
 

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,9 @@
 # Site settings
 title: Jessica Temporal
 tagline: Posts about python, data science, git, open source and more 😉
-email: hello@jtemporal.com
+contact_form:
+  en: https://jesstemporal.notion.site/27252b5614cf4a3cb75df604432a912e
+  pt: https://jesstemporal.notion.site/3919dd3e5b6c80f0bbf8de4876374909
 description: > # this means to ignore newlines until "baseurl:"
   Sr. Dev Advocate 🥑 • 🎙 Podcaster @pizzadedados • Creator of @gitfichas • GitHub ⭐️ • cross stitch & knitter • 🇧🇷 & 🇨🇦 • she/her •
   Opinions are my own.

--- a/_dev_config.yml
+++ b/_dev_config.yml
@@ -8,7 +8,9 @@
 # Site settings
 title: Jessica Temporal
 tagline: Posts about python, data science, git, open source and more 😉
-email: hello@jtemporal.com
+contact_form:
+  en: https://jesstemporal.notion.site/27252b5614cf4a3cb75df604432a912e
+  pt: https://jesstemporal.notion.site/3919dd3e5b6c80f0bbf8de4876374909
 description: > # this means to ignore newlines until "baseurl:"
   Sr. Dev Advocate 🥑 • 🎙 Podcaster @pizzadedados • Creator of @gitfichas • GitHub ⭐️ • cross stitch & knitter • 🇧🇷 & 🇨🇦 • she/her •
   Opinions are my own.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,8 +28,13 @@
             <svg class="h-7 w-7" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.026 2.747-1.026.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"></path></svg>
           </a>
         {% endif %}
-        {% if site.email %}
-          <a class="text-on-surface-variant transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="mailto:{{ site.email }}" aria-label="Email">
+        {% if site.contact_form %}
+          {% if current_lang == "en" %}
+            {% assign contact_form_url = site.contact_form.en %}
+          {% else %}
+            {% assign contact_form_url = site.contact_form.pt %}
+          {% endif %}
+          <a class="text-on-surface-variant transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="{{ contact_form_url }}" target="_blank" rel="noopener" aria-label="Contact form">
             <span class="material-symbols-outlined text-[28px]">mail</span>
           </a>
         {% endif %}

--- a/_includes/socials-logic.html
+++ b/_includes/socials-logic.html
@@ -10,4 +10,20 @@
       <span class="material-symbols-outlined text-primary opacity-0 transition-all group-hover:translate-x-2 group-hover:opacity-100">arrow_forward</span>
     </a>
   {% endfor %}
+  {% if site.contact_form %}
+    {% if current_lang == "en" %}
+      {% assign contact_form_url = site.contact_form.en %}
+      {% assign contact_form_name = "Contact form" %}
+    {% else %}
+      {% assign contact_form_url = site.contact_form.pt %}
+      {% assign contact_form_name = "Formulário de contato" %}
+    {% endif %}
+    <a class="group flex items-center justify-between py-6 no-underline transition-all duration-300 hover:pl-4" href="{{ contact_form_url }}" target="_blank" rel="noopener noreferrer">
+      <div class="flex items-center gap-6">
+        <span class="material-symbols-outlined text-3xl text-on-surface-variant transition-colors group-hover:text-primary dark:text-inverse-on-surface/70">mail</span>
+        <h3 class="font-display text-headline-sm text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">{{ contact_form_name }}</h3>
+      </div>
+      <span class="material-symbols-outlined text-primary opacity-0 transition-all group-hover:translate-x-2 group-hover:opacity-100">arrow_forward</span>
+    </a>
+  {% endif %}
 </div>

--- a/contact.md
+++ b/contact.md
@@ -10,4 +10,4 @@ translations:
     url: "/digaoi"
 ---
 
-You can talk to min [via Telegram](https://t.me/jtemporal) or if you prefer [send me an e-mail](mailto:hello@jtemporal.com).
+You can [fill out my contact form](https://jesstemporal.notion.site/27252b5614cf4a3cb75df604432a912e).

--- a/digaoi.md
+++ b/digaoi.md
@@ -10,4 +10,4 @@ translations:
     url: "/contact"
 ---
 
-Você pode falar comigo [pelo Telegram aqui](https://t.me/jtemporal) ou se preferir [me mandar um e-mail aqui](mailto:hello@jtemporal.com).
+Você pode [preencher meu formulário de contato aqui](https://jesstemporal.notion.site/3919dd3e5b6c80f0bbf8de4876374909).

--- a/sobre.md
+++ b/sobre.md
@@ -27,6 +27,6 @@ Além disso, continuo contribuindo e mantendo projetos de código aberto no GitH
 
 ### Entre em contato
 
-Você pode falar comigo [pelo Telegram aqui](https://t.me/jtemporal) ou se preferir [me mandar um e-mail aqui](mailto:hello@jtemporal.com).
+Você pode [preencher meu formulário de contato aqui](https://jesstemporal.notion.site/3919dd3e5b6c80f0bbf8de4876374909).
 
 {% include signature.html %}


### PR DESCRIPTION
## Summary

Replaces public `hello@jtemporal.com` contact points with language-specific Notion contact forms.

## Changes

- **Config**: replace `email` with `contact_form.en` / `contact_form.pt` in `_config.yml` and `_dev_config.yml`
- **Contact pages**: `contact.md`, `digaoi.md`, and `sobre.md` now link only to the Notion form (Telegram removed)
- **Footer**: mail icon opens the language-appropriate contact form in a new tab
- **Socials**: contact form added as the last item on `/socials/` and `/sociais/`
- **README**: contact section updated

## Contact form URLs

- English: https://jesstemporal.notion.site/27252b5614cf4a3cb75df604432a912e
- Portuguese: https://jesstemporal.notion.site/3919dd3e5b6c80f0bbf8de4876374909