### PR TITLE
Fix video page layout: sidebar banner and full-width list

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,5 +1,5 @@
 <aside class="space-y-8 lg:col-span-4">
-  {% if page.layout == "post" and page.type != "video" %}
+  {% if page.layout == "post" %}
     <div class="overflow-hidden rounded-2xl border bg-surface-container-lowest shadow-cozy dark:bg-inverse-surface {% if page.lang == 'pt' %}border-2 border-primary/25 dark:border-primary/40{% else %}border border-outline-variant dark:border-outline{% endif %}">
       {% include post-tag-banner.html post=page %}
     </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,8 +3,8 @@ layout: default
 ---
 
 <div class="site-container py-12">
-  <div class="grid grid-cols-1 gap-12 lg:grid-cols-12">
-    <article class="lg:col-span-8">
+  {% if page.hide_sidebar %}
+    <article>
       {% unless page.hide_header %}
         <header class="mb-10">
           <h1 class="font-display text-display-lg-mobile md:text-display-lg text-on-surface dark:text-inverse-on-surface">
@@ -18,7 +18,24 @@ layout: default
         {{ content }}
       </div>
     </article>
+  {% else %}
+    <div class="grid grid-cols-1 gap-12 lg:grid-cols-12">
+      <article class="lg:col-span-8">
+        {% unless page.hide_header %}
+          <header class="mb-10">
+            <h1 class="font-display text-display-lg-mobile md:text-display-lg text-on-surface dark:text-inverse-on-surface">
+              {{ page.title }}{% if page.subtitle %}: {{ page.subtitle }}{% endif %}
+            </h1>
+            <div class="mt-4 h-1 w-20 rounded-full bg-primary"></div>
+          </header>
+        {% endunless %}
 
-    {% include sidebar.html %}
-  </div>
+        <div class="prose-ink font-sans">
+          {{ content }}
+        </div>
+      </article>
+
+      {% include sidebar.html %}
+    </div>
+  {% endif %}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,12 +25,6 @@ layout: default
 
   <div class="grid grid-cols-1 gap-12 lg:grid-cols-12">
     <article class="lg:col-span-8" itemscope itemtype="http://schema.org/BlogPosting">
-      {% if page.type == "video" %}
-        <div class="mb-8 overflow-hidden rounded-2xl border border-outline-variant bg-surface-container-lowest shadow-cozy dark:border-outline dark:bg-inverse-surface">
-          {% include post-tag-banner.html post=page %}
-        </div>
-      {% endif %}
-
       <header class="mb-10">
         <h1 class="font-display text-display-lg-mobile md:text-display-lg leading-tight text-on-surface dark:text-inverse-on-surface" itemprop="name headline">{{ page.title }}</h1>
         {% if page.subtitle %}

--- a/videos.md
+++ b/videos.md
@@ -6,7 +6,7 @@ image: /images/logo.webp
 permalink: "/videos/"
 lang: en
 hide_header: true
-hide_sidebar_image: true
+hide_sidebar: true
 translations:
   - lang: pt
     url: "/videos"


### PR DESCRIPTION
## Summary

Fixes two layout issues on the video pages introduced during the Ethereal Ink theme migration.

- **Individual video posts:** The tag banner now appears in the sidebar (like regular posts) instead of above the article title.
- **Videos listing (`/videos/`):** The page now uses the full container width by hiding the empty sidebar column.

## Changes

- `_layouts/post.html` — remove top-of-article banner for `type: video` posts
- `_includes/sidebar.html` — show tag banner in sidebar for all posts, including videos
- `_layouts/page.html` — add `hide_sidebar` frontmatter option for full-width pages
- `videos.md` — set `hide_sidebar: true`

## Preview

Verified locally at:
- http://127.0.0.1:4000/videos/
- http://127.0.0.1:4000/agenticstack-compare-ai-agent-tools-short/