### PR TITLE
Fix Lil Jess dismiss ✕ lingering on mobile

### DIFF
--- a/_includes/lil-jess.html
+++ b/_includes/lil-jess.html
@@ -10,8 +10,10 @@
     align-items: flex-end;
     pointer-events: none;
   }
-  #lil-jess > * { pointer-events: auto; }
+  /* display:flex above beats the UA [hidden] rule without this. */
+  #lil-jess[hidden],
   #lil-jess [hidden] { display: none !important; }
+  #lil-jess > * { pointer-events: auto; }
 
   #lil-jess .lj-bubble {
     max-width: 220px;
@@ -67,9 +69,11 @@
     100% { transform: translateY(0) scale(1); }
   }
 
+  /* Anchored to the character so it leaves with her on dismiss. */
   #lil-jess .lj-close {
     position: absolute;
-    top: -0.25rem;
+    /* .lj-char is 76px; pin the ✕ to its top-right corner. */
+    bottom: calc(76px - 0.25rem);
     right: -0.25rem;
     width: 22px;
     height: 22px;
@@ -81,13 +85,16 @@
     line-height: 1;
     cursor: pointer;
     opacity: 0;
-    transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease, transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+    /* Match .lj-char's off-screen start so they enter/exit together. */
+    transform: translateY(140%);
   }
-  #lil-jess:hover .lj-close,
-  #lil-jess:focus-within .lj-close { opacity: 1; }
-  /* Touch screens have no hover — keep the dismiss button visible. */
+  #lil-jess.lj-in .lj-close { transform: translateY(0); }
+  #lil-jess.lj-in:hover .lj-close,
+  #lil-jess.lj-in:focus-within .lj-close { opacity: 1; }
+  /* Touch screens have no hover — keep the dismiss button visible while she's in. */
   @media (hover: none) {
-    #lil-jess .lj-close { opacity: 0.85; }
+    #lil-jess.lj-in .lj-close { opacity: 0.85; }
   }
 
   #lil-jess .lj-confetti {
@@ -104,6 +111,7 @@
     #lil-jess .lj-char { transition: none; }
     #lil-jess .lj-char.lj-bounce { animation: none; }
     #lil-jess .lj-bubble { transition: opacity 0.2s ease; transform: none; }
+    #lil-jess .lj-close { transition: opacity 0.2s ease; }
   }
 </style>
 


### PR DESCRIPTION
## Summary
- After dismissing Lil Jess on mobile, the ✕ stayed on screen even though she closed.
- Root cause: `#lil-jess { display: flex }` could keep the widget in layout when `hidden` was set, while the character slid off-screen and the touch-only ✕ stayed visible.
- Fix: force `#lil-jess[hidden] { display: none !important }`, only show the dismiss control while `.lj-in`, and animate the ✕ out with the character.

Fixes #14 

## Test plan
- [ ] Open site on a phone (or real touch device; DevTools resize alone does not flip `hover: none`)
- [ ] Confirm Lil Jess appears and the ✕ is visible
- [ ] Dismiss with ✕ — character and ✕ both leave; no floating ✕ remains
- [ ] Reload — she stays dismissed
- [ ] Re-summon with 5 footer taps (or type `jess` on desktop) — she returns cleanly
- [ ] Desktop: ✕ still appears on hover/focus only