### PR TITLE
Update docs after new-blog → jtemporal.github.io migration

### DIFF
--- a/.grok/skills/hidden-video-posts/SKILL.md
+++ b/.grok/skills/hidden-video-posts/SKILL.md
@@ -14,7 +14,7 @@ description: >
 
 ## Quick checklist
 
-1. `git worktree add ../new-blog-hidden-post-<slug> -b hidden-post-<slug> origin/main`
+1. `git worktree add ../jtemporal.github.io-hidden-post-<slug> -b hidden-post-<slug> origin/main`
 2. Draft `_posts/YYYY-MM-DD-<slug>-short.md` using the template in `AGENTS.md`
 3. `RBENV_VERSION=3.4.1 bundle exec jekyll serve --config _dev_config.yml --future`
 4. Share preview URL — **stop here until approved**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,14 +30,14 @@ These posts syndicate video transcripts to Medium and/or [dev.to](https://dev.to
 One isolated worktree per post or feature. Never stack unrelated post work or feature on the same branch.
 
 ```bash
-# From the main repo checkout (new-blog/)
+# From the main repo checkout (jtemporal.github.io/)
 git fetch origin
-git worktree add ../new-blog-hidden-post-<slug> -b hidden-post-<slug> origin/main
+git worktree add ../jtemporal.github.io-hidden-post-<slug> -b hidden-post-<slug> origin/main
 ```
 
 | Item | Pattern | Example |
 |------|---------|---------|
-| Worktree path | `../new-blog-hidden-post-<slug>` | `new-blog-hidden-post-gitkeep` |
+| Worktree path | `../jtemporal.github.io-hidden-post-<slug>` | `jtemporal.github.io-hidden-post-gitkeep` |
 | Branch | `hidden-post-<slug>` | `hidden-post-gitkeep` |
 | Post file | `_posts/YYYY-MM-DD-<slug>-short.md` | `_posts/2026-06-25-gitkeep-track-empty-folders-short.md` |
 
@@ -47,7 +47,7 @@ Before pushing, rebase onto latest `main` if other PRs merged:
 git fetch origin && git rebase origin/main
 ```
 
-After a PR is merged, clean up the worktree **from the main repo checkout** (`new-blog/` on `main`):
+After a PR is merged, clean up the worktree **from the main repo checkout** (`jtemporal.github.io/` on `main`):
 
 ```bash
 # 1. Confirm the PR landed on main
@@ -55,7 +55,7 @@ git fetch origin
 git log origin/main --oneline | head -5   # should show the merge commit
 
 # 2. Remove the worktree (add --force if it has uncommitted changes you no longer need)
-git worktree remove ../new-blog-hidden-post-<slug>
+git worktree remove ../jtemporal.github.io-hidden-post-<slug>
 
 # 3. Delete the local branch
 git branch -d hidden-post-<slug>
@@ -65,7 +65,7 @@ git worktree prune
 
 # 5. If the folder still exists on disk, delete it manually
 #    (this happens when the worktree was already unlinked but left a _site/ or other junk behind)
-rm -rf ../new-blog-hidden-post-<slug>
+rm -rf ../jtemporal.github.io-hidden-post-<slug>
 ```
 
 Verify cleanup with `git worktree list` — only active worktrees should remain. Do **not** delete worktrees for posts that are still in progress or awaiting publish.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Jess Temporal's Blog & Portfolio
 
-[![GitHub Pages](https://img.shields.io/badge/Hosted%20on-GitHub%20Pages-blue?logo=github)](https://jtemporal.com)
+[![Netlify](https://img.shields.io/badge/Hosted%20on-Netlify-00C7B7?logo=netlify&logoColor=white)](https://jtemporal.com)
 [![Jekyll](https://img.shields.io/badge/Built%20with-Jekyll-red?logo=jekyll)](https://jekyllrb.com/)
 
-Personal blog and portfolio website of Jessica Temporal — Sr. Dev Advocate, podcaster, and creator. Built with Jekyll and the **Ethereal Ink** theme, hosted on GitHub Pages.
+Personal blog and portfolio website of Jessica Temporal — Sr. Dev Advocate, podcaster, and creator. Built with Jekyll and the **Ethereal Ink** theme, hosted on Netlify.
 
 🌐 **Live site**: [jtemporal.com](https://jtemporal.com)
-
-> **Repository note:** This project currently lives at [`jtemporal/new-blog`](https://github.com/jtemporal/new-blog) while the Ethereal Ink migration is in progress. Clone and setup instructions below still use [`jtemporal/jtemporal.github.io`](https://github.com/jtemporal/jtemporal.github.io) — the repo will be renamed once the migration ships.
 
 ## About
 
@@ -22,8 +20,8 @@ This site features:
 
 - **Static site generator**: Jekyll 4.3
 - **Styling**: Tailwind CSS (Ethereal Ink design system) with Typography plugin
-- **Syntax highlighting**: Rouge
-- **Hosting**: GitHub Pages
+- **Syntax highlighting**: Rouge (with line numbers)
+- **Hosting**: Netlify (deploys from `main`; PR deploy previews)
 - **Domain**: [jtemporal.com](https://jtemporal.com)
 - **Analytics**: Google Analytics & PostHog
 
@@ -35,6 +33,7 @@ This site features:
 - Post tag banners, series pages, and listing pages for talks, videos, and books
 - Blog post pagination
 - Language switcher
+- Per-post OG social cards (`images/og/<slug>.png`)
 - Lil Jess, a friendly sidekick always visible in the corner (dismiss with ✕; type `jess` or 5 footer taps to bring her back)
 
 ### Multi-Language System
@@ -45,13 +44,17 @@ See [MULTI_LANGUAGE_SYSTEM.md](MULTI_LANGUAGE_SYSTEM.md) for architecture, trans
 
 See [LIL_JESS.md](LIL_JESS.md) for always-on visibility, dismiss/re-summon, reactions, and how to tweak her moods and lines.
 
+### Agent workflows
+
+See [AGENTS.md](AGENTS.md) for hidden YouTube short transcript posts, git worktree conventions, and OG card generation.
+
 ## Local Development
 
 ### Prerequisites
 
 - Ruby **3.4.1** (see `.ruby-version`)
 - Bundler
-- Node.js & npm (for Tailwind CSS builds)
+- Node.js & npm (for Tailwind CSS builds and OG card generation)
 - Git
 
 ### Setup
@@ -61,13 +64,6 @@ See [LIL_JESS.md](LIL_JESS.md) for always-on visibility, dismiss/re-summon, reac
    ```bash
    git clone https://github.com/jtemporal/jtemporal.github.io.git
    cd jtemporal.github.io
-   ```
-
-   If you are working from the migration repo before the rename:
-
-   ```bash
-   git clone https://github.com/jtemporal/new-blog.git
-   cd new-blog
    ```
 
 2. **Install dependencies**
@@ -105,8 +101,9 @@ See [LIL_JESS.md](LIL_JESS.md) for always-on visibility, dismiss/re-summon, reac
 | `npm run dev` | Build CSS and serve with `_dev_config.yml` |
 | `npm run build:css` | Compile Tailwind → `assets/css/main.css` |
 | `npm run watch:css` | Watch and rebuild CSS |
+| `npm run og:generate -- _posts/<file>.md` | Generate OG card for one post |
+| `npm run og:generate:all` | Generate OG cards for all posts |
 | `bundle exec jekyll build` | Production build |
-| `bundle exec jekyll serve --drafts` | Include draft posts |
 | `bundle exec jekyll serve --future` | Include future-dated posts |
 | `bundle exec jekyll clean` | Remove `_site` and cache |
 
@@ -119,11 +116,14 @@ See [LIL_JESS.md](LIL_JESS.md) for always-on visibility, dismiss/re-summon, reac
 ├── _hacktoberfest_projects_*/ # Hacktoberfest listings by year
 ├── _includes/                 # Reusable templates
 ├── _layouts/                  # Page layouts
-├── _plugins/                  # Jekyll plugins (CSS build, Rouge tweaks)
+├── _plugins/                  # Jekyll plugins (CSS, OG images, Rouge, series)
 ├── _data/                     # YAML data (socials, localization, etc.)
 ├── src/styles/                # Tailwind source (tailwind.css, theme.css, syntax.css)
 ├── assets/css/                # Compiled CSS
 ├── images/                    # Image assets
+├── images/og/                 # Per-post OG social cards
+├── og-templates/              # HTML template for OG card generation
+├── scripts/                   # OG generation, image optimization helpers
 └── slides/                    # Presentation slides
 ```
 
@@ -142,7 +142,7 @@ YYYY-MM-DD-post-title.md
 ```yaml
 ---
 layout: post
-title: "Your Post Title"
+title: "Your post title"
 date: 2025-08-30
 image: /images/covers/tutorial.webp
 tags: [tag1, tag2]
@@ -156,6 +156,28 @@ Your post content here...
 ```
 
 For translation details, see [MULTI_LANGUAGE_SYSTEM.md](MULTI_LANGUAGE_SYSTEM.md).
+
+### OG social cards
+
+Every new post (blog post, `type: video`, or `type: talk`) needs its own OG card. Do not reuse a generic cover as the social preview.
+
+```bash
+# Single post
+npm run og:generate -- _posts/YYYY-MM-DD-<slug>.md
+
+# Bilingual pair
+npm run og:generate -- _posts/YYYY-MM-DD-<slug-en>.md _posts/YYYY-MM-DD-<slug-pt>.md
+```
+
+This writes `images/og/<slug>.png`. Commit the PNG with the post. The `_plugins/og_image.rb` plugin uses that file as the social/featured image when present.
+
+Theme cues come from front matter (`type`, `tags`, `image`). See [AGENTS.md](AGENTS.md) for full details.
+
+### Images
+
+- Keep originals under `/images/`
+- Optimize with `python scripts/image_optmizer.py` (converts to WebP)
+- Prefer WebP paths in content
 
 ## Collections
 
@@ -171,6 +193,7 @@ Organized by year in `_hacktoberfest_projects_YYYY/`.
 
 - **Production config**: `_config.yml`
 - **Development config**: `_dev_config.yml` (local URLs, dev-only excludes)
+- **Netlify**: `netlify.toml` (build, deploy previews, caching headers)
 - **Styling**: `src/styles/tailwind.css`, `tailwind.config.js`, `src/styles/theme.css`
 
 ## Contributing


### PR DESCRIPTION
## Summary

- Refresh the README for the post-migration site: Netlify hosting, OG social cards, agent workflow pointers, and remove temporary `new-blog` clone notes.
- Rename agent worktree path conventions from `new-blog-*` to `jtemporal.github.io-*` in `AGENTS.md` and the hidden-video-posts skill.

## Test plan

- [ ] Skim README for accuracy (setup, commands, hosting)
- [ ] Confirm worktree examples in `AGENTS.md` match local path conventions
- [ ] No functional site changes expected (docs only)