### PR TITLE
Add five English translations from Notion

### DIFF
--- a/_posts/2018/2018-03-19-formatando-codigo-go.md
+++ b/_posts/2018/2018-03-19-formatando-codigo-go.md
@@ -13,6 +13,10 @@ tags:
 - português
 lang: pt
 comments: true
+last_modified_at: 2026-07-26
+translations:
+- lang: en
+  url: /using-go-to-format-go-code
 ---
 
 Coisa linda de se ver é usar um formatador de código, principalmente quando você tem preguiça de ficar formatando coisas ou quando você está preocupada em aprender a sintaxe de uma nova linguagem e ainda não pegou o jeito com o estilo de código.

--- a/_posts/2018/2018-03-19-using-go-to-format-go-code.md
+++ b/_posts/2018/2018-03-19-using-go-to-format-go-code.md
@@ -1,0 +1,76 @@
+---
+title: "Using Go to format Go code"
+layout: post
+date: '2018-03-19 05:00:00'
+last_modified_at: 2026-07-26
+image: "/images/covers/pro_tip.webp"
+type: post
+tags:
+- pro tip
+- go
+- gophers
+- golang
+- formatting
+- english
+lang: en
+comments: true
+description: Learn how gofmt helps you format Go code without the pain.
+translations:
+- lang: pt
+  url: /formatando-codigo-go
+---
+
+Code formatters are a beautiful thing to see, especially when you're feeling lazy about formatting things or when you're worried about learning a new language's syntax and haven't gotten the hang of the code style yet.
+
+Today's tip shows how the [Go programming language](https://golang.org/) helps you format code without suffering.
+
+To start, we need to understand that well-formatted code has been part of Go's culture since it was created. For the more experienced, this is just a very common best practice. But how does this work in practice? Alright, let's say you wrote the following code in a file called `helloworld.go`:
+
+```go
+package main
+import "fmt"
+func main(){
+fmt.Println("Hello world!")
+}
+```
+
+So far so good, this code compiles and if you do `go run helloworld.go` it still prints your `Hello World!` to the screen. However, if you had to send this code to an open source project, people reviewing your code would probably ask you to format it better.
+
+There are a bunch of language-native tools to help the developer, one of them being `gofmt`. It can show the suggested formatting for a source code on the screen or even format the code you write for you. To use `gofmt` just pass the filename to it:
+
+```console
+gofmt helloworld.go
+```
+
+That will print the formatted version of your source code to the screen. There are some flags you can use to change that result. For example, the `-d` flag will show a diff of your file in a format identical to `git diff`, great for sending patches.
+
+But the most interesting flag/option is `-w` which converts the screen output to writing in the file. In that case, if you use that flag like so:
+
+```console
+gofmt -w helloworld.go
+```
+
+Nothing will be printed to the screen and the formatted code will be written to your source file. So that code I showed at the beginning, after running with the `-w` flag, looks like this:
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+        fmt.Println("Hello World!")
+}
+```
+
+Cool right? Now you have no more excuse not to format your pretty little code 😜
+
+---
+
+## Links
+
+- Part of the [Essential Go book that talks about `go fmt`](https://www.programming-books.io/essential/go/323-go-fmt)
+- Documentation about [Go code formatting on Effective Go](https://golang.org/doc/effective_go.html#formatting)
+
+## Acknowledgments
+
+Thanks especially to Cesar who has patiently been teaching me Go.

--- a/_posts/2018/2018-11-17-subindo-imagens-docker-pro-dockerhub.md
+++ b/_posts/2018/2018-11-17-subindo-imagens-docker-pro-dockerhub.md
@@ -17,6 +17,10 @@ tags:
 - conteiner
 - conteiners
 comments: true
+last_modified_at: 2026-07-26
+translations:
+- lang: en
+  url: /uploading-docker-images-to-dockerhub
 ---
 
 Já achou mágico aquelas imagens pros containers docker que qualquer um pode usar e já pensou em fazer uma mas não sabe como? Vem que eu te ensino 😉
@@ -39,7 +43,7 @@ Agora vamos fazer o build da nossa imagem:
 <i>docker build -t sum .</i>
 </center>
 
-Aqui usamos o parâmetro `-t` para dar nome à nossa imagem. Depois de fazer o build podemos conferir a imagem na nossa lista de imagens disponíveis localmente: 
+Aqui usamos o parâmetro `-t` para dar nome à nossa imagem. Depois de fazer o build podemos conferir a imagem na nossa lista de imagens disponíveis localmente:
 
 ![listagem de imagens antes do tag](https://raw.githubusercontent.com/jtemporal/autom-dockerhub-example/master/gifs/docker-images-before-tag.gif)
 <center>

--- a/_posts/2018/2018-11-17-uploading-docker-images-to-dockerhub.md
+++ b/_posts/2018/2018-11-17-uploading-docker-images-to-dockerhub.md
@@ -1,0 +1,135 @@
+---
+title: "Uploading Docker images to Docker Hub"
+layout: post
+image: "/images/covers/tutorial.webp"
+date: '2018-11-17 08:00:00'
+last_modified_at: 2026-07-26
+type: post
+lang: en
+tags:
+- tutorial
+- docker hub
+- automation
+- docker
+- english
+- container
+- containers
+comments: true
+description: Learn how to build, tag, and push Docker images to Docker Hub — manually and with a shell script.
+translations:
+- lang: pt
+  url: /subindo-imagens-docker-pro-dockerhub
+---
+
+Ever thought those Docker container images that anyone can use are magical, and thought about making one but don't know how? Come along, I'll teach you 😉
+
+To start, you'll need a [Docker Hub](https://hub.docker.com/) account. That's where all Docker container images live. Once you've got your account there, we can move to the command line and start using the Docker CLI.
+
+Before we do anything, we need a project right? The project we're going to use here [is in this GitHub repo](https://github.com/jtemporal/autom-dockerhub-example). It's just a Python script that adds two numbers passed on the command line.
+
+Now that we have a project let's start with the *login*. Even though you don't need to *login* to build your images, once you're *logged in* you can forget it exists:
+
+![login](https://raw.githubusercontent.com/jtemporal/autom-dockerhub-example/master/gifs/docker-login.gif)
+<center>
+<i>docker login</i>
+</center>
+
+Now let's build our image:
+
+![docker image build](https://raw.githubusercontent.com/jtemporal/autom-dockerhub-example/master/gifs/docker-build-sum.gif)
+<center>
+<i>docker build -t sum .</i>
+</center>
+
+Here we used the `-t` parameter to name our image. After building we can check the image in our list of locally available images:
+
+![image listing before tag](https://raw.githubusercontent.com/jtemporal/autom-dockerhub-example/master/gifs/docker-images-before-tag.gif)
+<center>
+<i>docker images | grep sum</i>
+</center>
+
+Now that we have an image ready, let's tag it and check that it was tagged correctly:
+
+![docker tag and image listing after tag](https://raw.githubusercontent.com/jtemporal/autom-dockerhub-example/master/gifs/docker-tag-sum.gif)
+<center>
+<i>docker tag sum $(echo DOCKER_USERNAME)/sum</i>
+</center>
+
+This step is basically what lets us distribute our images. So after tagging your image, it's time to push (send the image to Docker Hub):
+
+![manual push of docker image](https://raw.githubusercontent.com/jtemporal/autom-dockerhub-example/master/gifs/docker-push-sum.gif)
+<center>
+<i>docker push $(echo DOCKER_USERNAME)/sum</i>
+</center>
+
+And done. Now the [image has been sent to Docker Hub](https://hub.docker.com/r/jtemporal/sum/), making it possible for anyone to use `docker pull` to download and use the image:
+
+![docker pull and image usage](https://raw.githubusercontent.com/jtemporal/autom-dockerhub-example/master/gifs/docker-pull.gif)
+<center>
+<i>docker pull jtemporal/sum && docker run --rm jtemporal/sum 4 2</i>
+</center>
+
+## Something extra
+
+Doing all these steps manually can get tiring if you need to push a lot of images, and beyond that, anything we do by hand can be prone to errors. So the natural path would be to automate these tasks.
+
+There are several ways to do this, but let's use a *shell script* I called `push.sh` for it:
+
+```bash
+#!/bin/bash
+
+if [ -z ${DOCKER_USERNAME} ]; then
+    echo "Missing DOCKER_USERNAME variable!"
+    exit 1
+fi
+
+error() {
+    if [ $? != 0 ]; then
+        echo "Error!"
+        exit 122
+    fi
+}
+
+build() {
+    echo "=> Building ${1}"
+    docker build -t ${1} .
+    echo "=> Built ${1}"
+}
+
+tag() {
+    echo "=> Tagging ${1}"
+    docker tag ${1} $(echo $DOCKER_USERNAME)/${1}
+    echo "=> Tagged ${1}"
+}
+
+push() {
+    echo "=> Pushing ${1}"
+    docker push $(echo $DOCKER_USERNAME)/${1}
+    echo "=> Pushed ${1}"
+}
+
+build ${1}
+error
+tag ${1}
+error
+push ${1}
+error
+echo
+
+exit 0
+```
+
+In it I reproduced all the steps we did up to here, and to use it just do:
+
+![automated push gif](https://raw.githubusercontent.com/jtemporal/autom-dockerhub-example/master/gifs/docker-automated-push.gif)
+<center>
+<i>./push.sh sum</i>
+</center>
+
+You can even put this script in a continuous delivery tool and let the magic happen.
+
+---
+
+## Links
+
+The code and steps demonstrated here [are in this GitHub repo](https://github.com/jtemporal/autom-dockerhub-example), go there and leave a ⭐️

--- a/_posts/2019/2019-03-15-diferenciando-json-loads-de-json-load-e-uma-pitade-de-bigquery.md
+++ b/_posts/2019/2019-03-15-diferenciando-json-loads-de-json-load-e-uma-pitade-de-bigquery.md
@@ -18,6 +18,10 @@ tags:
 - serialization
 - serialize
 description: Aprenda a diferenciar json.loads de json.load no Python
+last_modified_at: 2026-07-26
+translations:
+- lang: en
+  url: /understanding-the-difference-between-json-loads-and-json-load
 
 ---
 Se você nunca entendeu a diferença entre `json.loads()` e `json.load()` chegou a hora de entender! Na colinha de hoje vamos aprender a diferenciar esse métodos deliciosos.

--- a/_posts/2019/2019-03-15-understanding-the-difference-between-json-loads-and-json-load.md
+++ b/_posts/2019/2019-03-15-understanding-the-difference-between-json-loads-and-json-load.md
@@ -1,0 +1,130 @@
+---
+layout: post
+title: Understanding the difference between json.loads and json.load
+date: 2019-03-15 03:00:00 +0000
+last_modified_at: 2026-07-26
+image: "/images/covers/variados.webp"
+comments: true
+type: post
+lang: en
+tags:
+- serialization
+- python
+- bigquery
+- sql
+- json
+- api
+- python3
+- load
+- english
+description: Learn how to tell json.loads and json.load apart in Python
+translations:
+- lang: pt
+  url: /diferenciando-json-loads-de-json-load-e-uma-pitade-de-bigquery
+---
+
+If you never really understood the difference between `json.loads()` and `json.load()`, it's time to get it! In today's tip we're going to learn how to tell these methods apart.
+
+## JSON
+
+If you made it here, you probably already know what JSON is. But in case you don't, let's recap: [JSON (*JavaScript Object Notation*)](http://json.org/) is a lightweight data-interchange format. It's easy to read and write, which makes it usable by humans, and it's also easy for machines to create and parse.
+
+If you've ever used APIs you've probably exchanged data with them using this format. Most modern programming languages offer some kind of JSON support. In Python's case, there's a structure that's almost the same thing as a JSON object: the dictionary.
+
+## The JSON module in Python
+
+Beyond a data structure, Python also ships out of the box with [a module for JSON manipulation](https://docs.python.org/3.5/library/json.html). To use this module just do the following:
+
+```python
+import json
+```
+
+Among the many methods, there are two that are the focus of today's tip: `.loads()` and `.load()`. Despite being very similar in result, they're different in how they work.
+
+## Data
+
+But before we start, let's grab some data. The other day I was taking a look at [BigQuery](https://cloud.google.com/bigquery/), which, among many cool things the tool lets you do, also gives access to a ton of public data. Among them GitHub data. A lot of that data is available via GitHub's own API, but if you want to learn to poke around in BigQuery, they've already made the data available for us inside it:
+
+![image showing the github dataset on bq](/images/bq-github.webp)
+
+Cute right? You can see from the image above that the `github_repos` dataset contains 9 tables. Among them a table called `languages`:
+
+![image showing the github languages table on bq](/images/bq-github-languages.webp)
+
+This table, while big, has few columns. Just 4, to be more exact:
+
+![image showing the schema of the github languages table on bq](/images/bq-github-languages-schema.webp)
+
+With BigQuery you can export data to your Google Drive account. And that's what I did. First I selected 100 rows from the table using the SQL query below:
+
+```sql
+SELECT * FROM `bigquery-public-data.github_repos.languages` LIMIT 100
+```
+
+And after the *query* ran I clicked the little BigQuery screen to export the results. When you export this data BigQuery creates a folder in your Drive:
+
+![image showing the exported data](/images/2019-03-15 19.16.34.webp)
+
+And inside that folder a file with the same name with a `.json` extension. I downloaded that file and renamed it to `bq-github-languages.json` just so it'd have a name more indicative of the data it contains.
+
+If you open this file you'll notice something that might be curious: instead of having a single JSON, the file actually has several separate JSONs, one JSON for each row of the table. And this brings us to our first method.
+
+## .load()
+
+`json.load()` takes something that is *"readable"*, that is, any Python structure that has the built-in `.read()` method. We can find this behaviour for example in files.
+
+So, if our file had one big JSON containing all our observations, we could use this method like so:
+
+```python
+with open('bq-github-languages.json') as file_data:
+    data = json.load(file_data)
+```
+
+If you try to do this to load the data from our file, you'll come face to face with an error:
+
+```
+JSONDecodeError: Extra data: line 2 column 1
+```
+
+Which makes total sense since we don't have just one JSON in our file, we have a collection of them, right? This forces us to read each line of the file like this:
+
+```python
+with open('bq-github-languages.json') as file_data:
+    data = file_data.readlines()
+```
+
+And that's fine, but this action brings the following result: instead of having a list with several dictionaries, you end up with a list of *strings*. And if the idea was to manipulate this data, *strings* aren't the best data structure for it. Which brings us to the next method.
+
+## .loads()
+
+I used to mix up how these two methods work all the time. Until, recently, something clicked. When you have *strings*, you should use `.loads()`. You can use the hint that comes from the name itself: `s` for *string*.
+
+![gif](https://media.giphy.com/media/IWOTlIqnWzTFe/giphy.gif)
+
+Then after reading the file line by line with `.readlines()` you can go through your list of *strings* item by item and turn it into a dictionary:
+
+```python
+for i, item in enumerate(data):
+    data[i] = json.loads(item)
+```
+
+or even use *list comprehensions* for it:
+
+```python
+data = [json.loads(d) for d in data]
+```
+
+And then we can see the result of that. `data[0]` will give something like this:
+
+```python
+{'repo_name': 'gopz4u/ready',
+ 'language': [{'name': 'C#', 'bytes': '27779'},
+  {'name': 'C++', 'bytes': '28415'},
+  {'name': 'CSS', 'bytes': '6475'},
+  {'name': 'HTML', 'bytes': '34293'},
+  {'name': 'Java', 'bytes': '117831'},
+  {'name': 'JavaScript', 'bytes': '205287'},
+  {'name': 'Objective-C', 'bytes': '118096'}]}
+```
+
+Cool right? Well, that's all for today!

--- a/_posts/2019/2019-06-03-como-ser-cientista-de-dados-usando-um-computador-da-xuxa.md
+++ b/_posts/2019/2019-06-03-como-ser-cientista-de-dados-usando-um-computador-da-xuxa.md
@@ -24,6 +24,10 @@ tags:
 comments: true
 description: 'A resposta simples: Nuvem! Vamos ver na prática como é viver com seus Jupyter
   Notebooks na nuvem'
+last_modified_at: 2026-07-26
+translations:
+- lang: en
+  url: /how-to-be-a-data-scientist-using-less-than-4gb-ram
 
 ---
 #### A resposta simples: Nuvem! Vamos ver na prática como é viver com seus Jupyter Notebooks na nuvem? Vaaamoooss!!!

--- a/_posts/2019/2019-06-03-how-to-be-a-data-scientist-using-less-than-4gb-ram.md
+++ b/_posts/2019/2019-06-03-how-to-be-a-data-scientist-using-less-than-4gb-ram.md
@@ -1,0 +1,153 @@
+---
+layout: post
+title: How to be a data scientist using less than 4GB of RAM
+date: 2019-06-03 09:00:00 -0300
+last_modified_at: 2026-07-26
+image: "/images/covers/tutorial.webp"
+type: post
+lang: en
+tags:
+- tutorial
+- jupyter
+- jupyter notebooks
+- ssh
+- cloud
+- cloud computing
+- data science
+- tunnel
+- portal
+- serenata de amor
+- open source
+- computer power
+- english
+comments: true
+description: "The simple answer: The Cloud! Let's see in practice what it's like to live with your Jupyter Notebooks in the cloud"
+translations:
+- lang: pt
+  url: /como-ser-cientista-de-dados-usando-um-computador-da-xuxa
+---
+
+#### The simple answer: The Cloud! Let's see in practice what it's like to live with your Jupyter Notebooks in the cloud? Let's goooo!!!
+
+A couple of years ago, while I was working on [Operação Serenata de Amor](https://serenata.ai/), my coworkers used to say I had a Xuxa's computer or something like that:
+
+<center><img src="https://cdn-images-1.medium.com/max/800/1*iu4Fht5QlGZcO-V30SjzxQ.jpeg"/><a href="https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/Pense_bem.jpg/1200px-Pense_bem.jpg">Source</a></center>
+
+Nothing against Xuxa's computers or the Pense Bem, but if you consider that when working with data science, *machine learning*, artificial intelligence and the like, neither Xuxa's computer, nor the Pense Bem, and not even 4GB of RAM are going to be enough to run tasks that require large amounts of data in memory at the same time.
+
+As a data scientist, most of the work involves "heavy" tasks. One solution to quickly work around a computer's lack of processing capacity is using a **machine in the cloud**.
+
+### Advantages
+
+But what makes the cloud so different? And what makes it such a magical place?
+
+Today, one of the biggest challenges in data science and more specifically in the [*big data*](https://podcast.pizzadedados.com/e/episodio-012-big-data/) area is being able to process a huge amount of data in a short time and without spending much on it. And, in those moments, the cloud is your best ally.
+
+Today, in Brazil, you can **not** find a light Notebook with a robust configuration, with more than 16GB of RAM and an SSD with more than 128GB, for less than 7 thousand reais. Coughing up that amount of money is beyond the financial reality of most people.
+
+*Data centers* of tech giants like [Digital Ocean](https://www.digitalocean.com/) (DO), [Amazon Web Services](https://aws.amazon.com/) (AWS), [Google Cloud](https://cloud.google.com/compute/docs/instances/) and [Azure](https://azure.microsoft.com/), have made low-cost access available to machines with more processing capacity than those 7 thousand reais notebooks. Plus, a connection with low bandwidth is enough to access your machine in the cloud and get your *scripts* running.
+
+These available machines can, in a matter of a few hours, execute processing that would take days or even wouldn't run at all on conventional computers.
+
+### Disadvantages
+
+But the cloud isn't all advantages, there are some points that still **bother me** when using it. For instance, all the companies that offer this kind of service with unimpeachable quality are foreign and charge in dollars. There's still a lack of a Brazilian service that's cheap and reliable enough to make us swap the services offered by DO and AWS for example.
+
+I'll still dare to say that, even though the machines are *plug-and-play*, some small configurations need to happen to actually guarantee the minimum usability, forcing the data scientist to wear more than one hat and, in this case, put on the [*SysAdmin*](https://en.wikipedia.org/wiki/System_administrator) hat too.
+
+### Jupyter in the cloud with diamonds
+
+Okay, but let's say you already have your beautiful little machine there on *insert-your-favorite-cloud-service-here*. Now what? What happens to [Jupyter Notebook](https://jupyter.org/)?
+
+[Ana Schwendler](https://medium.com/u/a84fab589b6c) [already talked about how](https://medium.com/data-science-brigade/validando-hip%C3%B3teses-d51ae1f46052) the Serenata scientists use Jupyter Notebooks to explore data and validate or reject hypotheses. Normally, the notebook is run locally on the machine of whoever is programming, but when the person starts using a machine in the cloud, how does that process go?
+
+### Living in the clouds
+
+<center>
+  <br>
+  <img src="https://cdn-images-1.medium.com/max/800/1*YK0o59-niSDgu_eCBTsECg.gif"/>
+  <br>
+  <a href="https://media.giphy.com/media/13bGgH9VnEDsuA/giphy.gif">Source</a>
+</center>
+
+The most practical way to access a machine in the cloud is via SSH connection. SSH is a protocol that [allows remote access to machines in a secure way](https://en.wikipedia.org/wiki/Secure_Shell). There are ways to establish an SSH connection using programs like [PuTTY](https://www.putty.org/) and [MobaXterm](https://mobaxterm.mobatek.net/), but if you have access to a terminal, you can also do this using a command, passing your user on the remote machine and the address (host) of that machine, something like:
+
+```console
+ssh user@host
+```
+
+*But what is this SSH anyway and how does it work?* In practice, SSH is nothing more than a secure way to *log into* a computer that is **not** right next to you and it works like a key and a lock. When you're going to enter your house, normally you have to unlock the lock, and SSH works exactly the same way, you have a pair of files that are called keys and they play the role of the house key and lock.
+
+So, instead of logging in traditionally with user and password, you can use SSH to connect to your machine in the cloud. All that's needed is that the server has your lock (public key) and that you have the key (private key) on your local machine. For those using programs like the ones I mentioned before, those programs take care of managing these keys for you.
+
+On a Linux server, the default place to find the locks is the *authorized_keys* file inside the `.ssh` folder. The cool part is that a single machine can have several public keys inside this file, so the whole team that needs to access that machine can. This allows, for example, resource sharing among team members, making the costs of running heavy tasks even cheaper.
+
+These days, since I work from a Windows computer, but being familiar with Linux, I use Git Bash, a [Bash terminal](https://en.wikipedia.org/wiki/Bash_%28Unix_shell%29) distributed with the Git installation and very useful ❤. Accessing the machine in the cloud via command line works for me, but if you prefer to use programs, feel free, whatever floats your boat, and you should pick whichever is more comfortable for you 😉. From here on I'm going to show how to use the terminal to do what we need. So, to access a machine using the terminal just do the following:
+
+```console
+$ ssh jessicatemporal@34.66.48.61
+```
+
+and there you are up in the clouds 😉
+
+Let's understand the command:
+
+- `ssh`: is the program for establishing an SSH connection;
+- `jessicatemporal`: is my access user on the machine up in the cloud;
+- `34.66.48.61`: is the IP address of the machine I want to access (here I'm showing you a fake IP just for illustration, okay?).
+
+Now that you've accessed your machine you can run the Jupyter Notebook:
+
+```console
+$ jupyter notebook --no-browser
+```
+
+Notice that I passed an extra parameter there, `--no-browser`, which makes the Jupyter Notebook run without opening a browser.
+
+### Living on portals
+
+When we run Jupyter Notebook on our computer, a communication channel is chosen so we can view our notebooks. This channel is known as a *port* and, in the Jupyter default configuration, it's `8888`. So we can access on our browser the path `https://localhost:8888` and run our notebooks right?
+
+But now Jupyter isn't running on your local computer, so we're going to use our SSH connection to connect one of the ports on our computer to the port on the server where Jupyter is running. For that, you use the `-L` argument which generates what's known as *port forwarding*. Your SSH access would look something like:
+
+```console
+$ ssh -L 8888:localhost:8080 jessicatemporal@34.66.48.61
+```
+
+In non-technical terms, *port forwarding* works like a portal.
+
+<center>
+  <br>
+  <img src="https://media.giphy.com/media/12VWf9OaUMlUyc/giphy.gif"/>
+  <br><a href="https://media.giphy.com/media/12VWf9OaUMlUyc/giphy.gif">Source</a>
+</center>
+
+If you create a portal to somewhere you can see what's going on in that place. That's also how we manage to establish a communication channel and know what's happening on the server, creating a tunnel (portal) that connects port `8080` on my local machine to port `8888` on the server:
+
+![image showing the tunnel in the terminal](https://cdn-images-1.medium.com/max/1200/1*J-HKcdqv-XcnH8eit8M7PQ.png)
+
+With that you can open your computer's browser and go to `https://localhost:8080` to see your notebooks:
+
+![image of the browser on localhost](https://cdn-images-1.medium.com/max/1200/1*zCgW_BhKtuxDiMNSNPix7A.png)
+
+### Finally
+
+After getting your Jupyter running in the cloud and accessing it using the tunnel, building the notebook itself doesn't change much. You'll keep doing your analyses like you normally do, with the small difference that now you have the power of the cloud within your reach.
+
+<center>
+  <br><img src="https://cdn-images-1.medium.com/max/800/1*5pXyE0DGdhS9GcefQgiBoQ.gif"/>
+  <br><a href="https://media.giphy.com/media/2xFZQFpPwIcs7Rx3ZF/giphy.gif">Source</a>
+</center>
+
+Now go out and conquer the cloud yourself! Xoxo.
+
+---
+
+### Tips
+
+If you want to learn more about SSH I recommend:
+
+- [Reading its manual](https://www.openssh.com/manual.html) as you need to;
+- [This post](http://www.alexonlinux.com/ssh-crash-course) which is a quick SSH crash course;
+- This [reference infographic](http://www.cheat-sheets.org/saved-copy/OpenSSH_quickref.pdf) about SSH;
+- If you want to run Jupyter on a Google Cloud instance [this post is kept in my heart](https://medium.com/@kn.maragatham09/installing-jupyter-notebook-on-google-cloud-11979e40cd10).

--- a/_posts/2022/2022-02-06-entenda-a-diferenca-git-stash-pop-git-stash-apply.md
+++ b/_posts/2022/2022-02-06-entenda-a-diferenca-git-stash-pop-git-stash-apply.md
@@ -19,6 +19,10 @@ posts_list:
 - usando-git-stash-e-git-stash-pop
 - para-que-serve-o-git-stash-drop
 - resolvendo-conflitos
+last_modified_at: 2026-07-26
+translations:
+- lang: en
+  url: /understand-the-difference-between-git-stash-apply-and-git-stash-pop
 
 ---
 Você pode saber criar seus stashes, listar eles e tudo mais, mas na hora de voltar a usar o trabalho salvo em um stash sempre rola aquela dúvida: “_apply ou pop? Eis a questão_”. E essa dúvida é muito normal já que ambos tem um funcionamento parecido, ambos aplicam as mudanças guardadas em um stash.

--- a/_posts/2022/2022-02-06-understand-the-difference-between-git-stash-apply-and-git-stash-pop.md
+++ b/_posts/2022/2022-02-06-understand-the-difference-between-git-stash-apply-and-git-stash-pop.md
@@ -1,0 +1,92 @@
+---
+layout: post
+date: 2022-02-06T09:00:00.000-02:00
+last_modified_at: 2026-07-26
+image: /images/covers/pro_tip.webp
+comments: true
+bookbanner: true
+title: Understand the difference between git stash apply and git stash pop
+description: They work similarly, but one fundamental difference changes when you should use each
+type: post
+lang: en
+series: "Git Pro Tips"
+series_order: 10
+tags:
+- git
+- english
+- pro tip
+related: true
+posts_list:
+- using-git-stash-and-git-stash-pop
+- why-the-git-stash-drop-is-useful
+- solving-conflicts
+translations:
+- lang: pt
+  url: /entenda-a-diferenca-git-stash-pop-git-stash-apply
+---
+
+You might know how to create your stashes, list them and all that, but when it's time to go back to using the work saved in a stash there's always that doubt: "*apply or pop? That is the question*". And that doubt is very normal since both work similarly, both apply the changes stored in a stash.
+
+In today's tip you're going to see when to use one and when to use the other. 😉
+
+## git stash apply
+
+`apply` like the name says applies the changes from a stash to your working directory but it also keeps the entry in the stash list. For example, consider you have the following stash stack:
+
+![image showing the list of stashes as a result of the git stash list command with two stashes in the list](/images/git-stash/listagem-stashes-fig1.webp)
+
+And you want to apply the changes from the first stash, `stash@{0}`. To do that, run the command:
+
+```console
+git stash apply
+```
+
+The expected result is finding the changes stored in that stash on your local branch:
+
+![image showing the result of the git stash apply command with the changes present](/images/git-stash/resultado-git-stash-apply-fig2.webp)
+
+And also finding those changes when listing the stashes:
+
+![image showing the list of stashes as a result of the git stash list command with two stashes in the list](/images/git-stash/listagem-stashes-fig1.webp)
+
+Note that `apply`, just like `drop` and `pop` without passing an index, will use the most recent stash on the stack.
+
+## git stash pop
+
+`pop`, in turn, will apply the changes from a stash to your working area and remove that stash from the stack right after. `pop` is nothing more than a shortcut for `git stash apply` followed by [`git stash drop`](/why-the-git-stash-drop-is-useful/).
+
+For example, taking into consideration the same stash list as before, and a working environment with no changes, you want to take from the list and apply the changes from the first stash, `stash@{0}`. So you run the command:
+
+```console
+git stash pop
+```
+
+The expected result is finding the changes stored in that stash on your local branch, just like with `apply`:
+
+![image showing the result of the git stash pop command with the changes present](/images/git-stash/resultado-git-stash-pop-fig3.webp)
+
+At the same time, differently from `apply`, it already shows that the corresponding stash was removed from the list in the result message. If you run `git stash list` you won't find that stash on the list anymore:
+
+![image showing the stash list with only one stash as a result of popping the most recent stash](/images/git-stash/listagem-stashes-pos-dropfig3.webp)
+
+## When to use apply and when to use pop
+
+Let's say you want to reuse the changes you made somewhere else too, or you're not sure if you want to use them now. Then you can use `apply` and, if you don't want to keep them, use `git reset HEAD` to discard them, keeping the changes stored in a stash for later.
+
+If you're sure you want to keep the changes, use `pop`. That way, besides applying the changes, you keep the stash list nice and clean. As a rule, I always prefer to use `pop` and redo the stash if I need to save the changes for later.
+
+The important part is that now you understand the difference between one and the other and you don't need to be afraid of `git stash` anymore.
+
+## GitFichas | GitStudyCards
+
+{% assign ficha_url = "https://gitfichas.com/en/045?utm_source=blog" %}
+{% assign ficha_img = "https://res.cloudinary.com/jesstemporal/image/upload/v1644148964/gitfichas/en/045/full_zugn9f.jpg" %}
+{% assign ficha_title = "GitFicha #045" %}
+{% assign ficha_description = "git stash drop" %}
+{% include ficha.html %}
+
+{% assign ficha_url = "https://gitfichas.com/en/044?utm_source=blog" %}
+{% assign ficha_img = "https://res.cloudinary.com/jesstemporal/image/upload/v1642964724/gitfichas/en/044/full_hvzjs2.jpg" %}
+{% assign ficha_title = "GitFicha #044" %}
+{% assign ficha_description = "git stash pop" %}
+{% include ficha.html %}


### PR DESCRIPTION
## Summary
- Add 5 finished PT → EN translations from Notion exports (one commit per post + twin)
- Link each EN/PT pair via `translations:` frontmatter

### Posts
| EN | PT |
|---|---|
| `using-go-to-format-go-code` | `formatando-codigo-go` |
| `uploading-docker-images-to-dockerhub` | `subindo-imagens-docker-pro-dockerhub` |
| `understanding-the-difference-between-json-loads-and-json-load` | `diferenciando-json-loads-de-json-load-e-uma-pitade-de-bigquery` |
| `how-to-be-a-data-scientist-using-less-than-4gb-ram` | `como-ser-cientista-de-dados-usando-um-computador-da-xuxa` |
| `understand-the-difference-between-git-stash-apply-and-git-stash-pop` | `entenda-a-diferenca-git-stash-pop-git-stash-apply` |

## Test plan
- [x] Previewed all 5 EN posts locally
- [x] Previewed PT twins and language switcher links
- [ ] Confirm Netlify preview after push