### PR TITLE
PageSpeed follow-ups: SEO, accessibility, and perf polish

### DIFF
--- a/_books/en/gitmicrobook.md
+++ b/_books/en/gitmicrobook.md
@@ -13,7 +13,7 @@ book_cover_ipad_alt: Cover from 'The Big Git Microbook' being shown in an iPad
 image: /images/books/git-microbook-banner.webp
 permalink: /gitmicrobook/
 purchase_button: Buy on
-know_more_button: Learn more
+know_more_button: About the book
 gumroad: https://jessicatemporal.gumroad.com/l/gitmicrobook?wanted=true
 amazon: https://www.amazon.com/dp/B0CDNX6NS7/ref=sr_1_1?&_encoding=UTF8&tag=jesstempora0e-20&linkCode=ur2&linkId=efc4229f6b816609dfce4f185781d99a&camp=1789&creative=9325
 translations:

--- a/_books/pt/microlivrodegit.md
+++ b/_books/pt/microlivrodegit.md
@@ -13,7 +13,7 @@ book_cover_ipad_alt: Capa do 'O Grande Micro Livro de Git' sendo mostrada num ip
 image: /images/livros/microlivro-banner.webp
 permalink: /microlivrodegit/
 purchase_button: Compre na
-know_more_button: Saiba mais
+know_more_button: Sobre o livro
 gumroad: https://jessicatemporal.gumroad.com/l/microlivrodegit?wanted=true
 amazon: https://amzn.to/3SETpx4
 translations:

--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ built-by:
 
 copyright:
    name: Jessica Temporal
-   link: 'https://jtemporal.com'
+   link: '/'
 
 # Build settings
 markdown: kramdown
@@ -55,23 +55,27 @@ languages:
     locale: "en_US"
     url: "/en/"
     text:
-      know_more_button: "Learn more"
+      know_more_button: "About the book"
       buy_button: "Buy on"
       recent_articles_title: "Recent Articles"
       related_articles_title: "Related Articles"
       author_note_title: "Author Note"
+      previous_page: "Previous page"
+      next_page: "Next page"
   pt:
     flag: "🇧🇷"
-    name: "Português" 
+    name: "Português"
     code: "pt"
     locale: "pt_BR"
     url: "/pt/"
     text:
-      know_more_button: "Saiba mais"
+      know_more_button: "Sobre o livro"
       buy_button: "Compre na"
       recent_articles_title: "Artigos recentes"
       related_articles_title: "Artigos relacionados"
       author_note_title: "Nota da autora"
+      previous_page: "Página anterior"
+      next_page: "Próxima página"
 
 # Default language
 default_language: en

--- a/_dev_config.yml
+++ b/_dev_config.yml
@@ -32,7 +32,7 @@ built-by:
 
 copyright:
    name: Jessica Temporal
-   link: 'https://jtemporal.com'
+   link: '/'
 
 # Build settings
 markdown: kramdown
@@ -55,23 +55,27 @@ languages:
     locale: "en_US"
     url: "/en/"
     text:
-      know_more_button: "Learn more"
+      know_more_button: "About the book"
       buy_button: "Buy on"
       recent_articles_title: "Recent Articles"
       related_articles_title: "Related Articles"
       author_note_title: "Author Note"
+      previous_page: "Previous page"
+      next_page: "Next page"
   pt:
     flag: "🇧🇷"
-    name: "Português" 
+    name: "Português"
     code: "pt"
     locale: "pt_BR"
     url: "/pt/"
     text:
-      know_more_button: "Saiba mais"
+      know_more_button: "Sobre o livro"
       buy_button: "Compre na"
       recent_articles_title: "Artigos recentes"
       related_articles_title: "Artigos relacionados"
       author_note_title: "Nota da autora"
+      previous_page: "Página anterior"
+      next_page: "Próxima página"
 
 # Default language
 default_language: en

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,7 +1,35 @@
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga4_id }}"></script>
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', '{{ site.ga4_id }}');
+  (function () {
+    var loaded = false;
+    function loadGA4() {
+      if (loaded) return;
+      loaded = true;
+      var s = document.createElement('script');
+      s.async = true;
+      s.src = 'https://www.googletagmanager.com/gtag/js?id={{ site.ga4_id }}';
+      document.head.appendChild(s);
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      window.gtag = gtag;
+      gtag('js', new Date());
+      gtag('config', '{{ site.ga4_id }}');
+    }
+
+    // Defer GA until the browser is idle, first interaction, or a short timeout.
+    // Keeps analytics without competing with first paint / main-thread work.
+    function schedule() {
+      if ('requestIdleCallback' in window) {
+        requestIdleCallback(loadGA4, { timeout: 4000 });
+      } else {
+        window.addEventListener('load', function () {
+          setTimeout(loadGA4, 2000);
+        });
+      }
+    }
+
+    ['pointerdown', 'keydown', 'scroll', 'touchstart'].forEach(function (evt) {
+      window.addEventListener(evt, loadGA4, { once: true, passive: true });
+    });
+    schedule();
+  })();
 </script>

--- a/_includes/author-note-widget.html
+++ b/_includes/author-note-widget.html
@@ -2,7 +2,7 @@
 {% assign author_note_title = site.languages[current_lang].text.author_note_title %}
 
 <div class="rounded-2xl border border-outline-variant bg-surface-container-low p-6 dark:border-outline dark:bg-inverse-surface">
-  <h3 class="mb-2 font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">{{ author_note_title }}</h3>
+  <h2 class="mb-2 font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">{{ author_note_title }}</h2>
   <p class="text-sm text-on-surface-variant dark:text-inverse-on-surface/80">
     <a class="text-primary transition-colors hover:underline" href="{{ page.author_note_link }}">{{ page.author_note_text }}</a>
   </p>

--- a/_includes/book-buy-banner.html
+++ b/_includes/book-buy-banner.html
@@ -1,33 +1,34 @@
 {% assign lang = page.lang == "en" or post.lang == "en" ? "en" : "pt" %}
+{% assign book = site.banner_books[lang].book %}
 {% if lang == "en" %}
-  {% assign knw_btn = "Learn more" %}
+  {% assign knw_btn = "About " | append: book.title %}
   {% assign buy = "Buy on" %}
 {% else %}
-  {% assign knw_btn = "Saiba mais" %}
+  {% assign knw_btn = "Sobre " | append: book.title %}
   {% assign buy = "Compre na" %}
 {% endif %}
 
 <section class="my-12 rounded-2xl border border-primary/20 bg-surface-container-low p-8 dark:border-primary/40 dark:bg-inverse-surface">
   <div class="flex flex-col gap-8 md:flex-row md:items-center">
     <div class="md:w-1/3">
-      <a href="{{ site.banner_books[lang].book.page }}">
-        <img class="mx-auto max-h-64 rounded-xl" src="{{ site.banner_books[lang].book.cover | relative_url }}" alt="{{ site.banner_books[lang].book.title }}">
+      <a href="{{ book.page }}" aria-label="{{ knw_btn }}">
+        <img class="mx-auto max-h-64 rounded-xl" src="{{ book.cover | relative_url }}" alt="{{ book.title }}" loading="lazy" decoding="async">
       </a>
     </div>
     <div class="md:w-2/3">
-      <h3 class="font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">
-        <a class="transition-colors hover:text-primary" href="{{ site.banner_books[lang].book.page }}">{{ site.banner_books[lang].book.title }}</a>
-      </h3>
+      <h2 class="font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">
+        <a class="transition-colors hover:text-primary" href="{{ book.page }}">{{ book.title }}</a>
+      </h2>
       {% if page.layout != "post" %}
-        <p class="mt-2 text-on-surface-variant dark:text-inverse-on-surface/80">{{ site.banner_books[lang].book.subtitle }}</p>
-        <p class="mt-4 text-on-surface-variant dark:text-inverse-on-surface/80">{{ site.banner_books[lang].book.short_description }}</p>
+        <p class="mt-2 text-on-surface-variant dark:text-inverse-on-surface/80">{{ book.subtitle }}</p>
+        <p class="mt-4 text-on-surface-variant dark:text-inverse-on-surface/80">{{ book.short_description }}</p>
       {% endif %}
       <div class="mt-6 flex flex-wrap gap-3">
         {% if page.layout == "post" %}
-          <a class="btn-secondary" href="{{ site.banner_books[lang].book.page }}">{{ knw_btn }}</a>
+          <a class="btn-secondary" href="{{ book.page }}">{{ knw_btn }}</a>
         {% endif %}
-        <a class="btn-primary" href="{{ site.banner_books[lang].book.gumroad }}">{{ buy }} Gumroad</a>
-        <a class="btn-primary" href="{{ site.banner_books[lang].book.amazon }}">{{ buy }} Amazon</a>
+        <a class="btn-primary" href="{{ book.gumroad }}">{{ buy }} Gumroad</a>
+        <a class="btn-primary" href="{{ book.amazon }}">{{ buy }} Amazon</a>
       </div>
     </div>
   </div>

--- a/_includes/book-chapters-grid.html
+++ b/_includes/book-chapters-grid.html
@@ -21,7 +21,7 @@
       <p class="mt-4 font-sans text-body-md text-secondary-fixed-dim">{{ page.bonus_chapter.description }}</p>
       {% if page.bonus_chapter.url %}
       <a class="mt-8 flex items-center gap-2 font-sans text-label-md font-medium uppercase tracking-wide text-tertiary-fixed no-underline transition-colors hover:text-tertiary-fixed-dim" href="{{ page.bonus_chapter.url }}">
-        {{ page.bonus_chapter.link_text | default: "Learn more" }}
+        {{ page.bonus_chapter.link_text | default: page.bonus_chapter.title }}
         <span class="material-symbols-outlined transition-transform group-hover:translate-x-1">arrow_right_alt</span>
       </a>
       {% endif %}

--- a/_includes/book-cta.html
+++ b/_includes/book-cta.html
@@ -1,7 +1,7 @@
 {% if page.gumroad %}
 <section class="mt-section-gap-lg flex flex-col items-center justify-between gap-gutter border border-secondary-fixed bg-surface-container-low p-12 font-sans dark:border-outline dark:bg-inverse-surface md:flex-row">
   <div>
-    <h3 class="font-display text-headline-md text-on-surface dark:text-inverse-on-surface">{{ page.cta_heading | default: page.title }}</h3>
+    <h2 class="font-display text-headline-md text-on-surface dark:text-inverse-on-surface">{{ page.cta_heading | default: page.title }}</h2>
     <p class="mt-2 font-sans text-body-md text-secondary dark:text-inverse-on-surface/70">{{ page.cta_description | default: page.description }}</p>
   </div>
   <div class="not-prose flex flex-col items-center gap-3">

--- a/_includes/book-faq.html
+++ b/_includes/book-faq.html
@@ -7,9 +7,9 @@
     {% for item in page.faq %}
     <div class="border-b border-secondary-fixed pb-8 dark:border-outline">
       {% if item.label %}
-      <h4 class="mb-2 font-sans text-label-md font-medium uppercase tracking-wide text-primary">{{ item.label }}</h4>
+      <p class="mb-2 font-sans text-label-md font-medium uppercase tracking-wide text-primary">{{ item.label }}</p>
       {% endif %}
-      <p class="font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">{{ item.question }}</p>
+      <h3 class="font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">{{ item.question }}</h3>
       <p class="mt-4 font-sans text-body-md text-secondary dark:text-inverse-on-surface/70">{{ item.answer }}</p>
     </div>
     {% endfor %}

--- a/_includes/book-widget.html
+++ b/_includes/book-widget.html
@@ -1,20 +1,25 @@
 {% include language-detection.html %}
-{% assign knw_btn = site.languages[current_lang].text.know_more_button %}
+{% assign book = site.banner_books[current_lang].book %}
 {% assign buy = site.languages[current_lang].text.buy_button %}
+{% if current_lang == "en" %}
+  {% assign knw_btn = "About " | append: book.title %}
+{% else %}
+  {% assign knw_btn = "Sobre " | append: book.title %}
+{% endif %}
 
 <div class="overflow-hidden rounded-2xl border border-outline-variant bg-surface-container-low shadow-sm transition-shadow hover:shadow-md dark:border-outline dark:bg-inverse-surface">
   <div class="relative aspect-[4/5] bg-surface-container">
-    <img class="h-full w-full object-cover" src="{{ site.banner_books[current_lang].book.cover | relative_url }}" alt="{{ site.banner_books[current_lang].book.title }}">
+    <img class="h-full w-full object-cover" src="{{ book.cover | relative_url }}" alt="{{ book.title }}" loading="lazy" decoding="async">
     <div class="absolute inset-0 flex items-end bg-gradient-to-t from-on-surface/60 to-transparent p-6">
-      <h4 class="font-display text-xl font-bold text-on-primary">{{ site.banner_books[current_lang].book.title }}</h4>
+      <h2 class="font-display text-xl font-bold text-on-primary">{{ book.title }}</h2>
     </div>
   </div>
   <div class="p-6">
-    <p class="mb-6 text-sm leading-relaxed text-on-surface-variant dark:text-inverse-on-surface/80">{{ site.banner_books[current_lang].book.short_description }}</p>
+    <p class="mb-6 text-sm leading-relaxed text-on-surface-variant dark:text-inverse-on-surface/80">{{ book.short_description }}</p>
     <div class="space-y-2">
-      <a class="btn-primary mb-2 block w-full text-center" href="{{ site.banner_books[current_lang].book.gumroad }}">{{ buy }} Gumroad</a>
-      <a class="btn-primary mb-2 block w-full text-center" href="{{ site.banner_books[current_lang].book.amazon }}">{{ buy }} Amazon</a>
-      <a class="btn-secondary block w-full text-center" href="{{ site.banner_books[current_lang].book.page }}">{{ knw_btn }}</a>
+      <a class="btn-primary mb-2 block w-full text-center" href="{{ book.gumroad }}">{{ buy }} Gumroad</a>
+      <a class="btn-primary mb-2 block w-full text-center" href="{{ book.amazon }}">{{ buy }} Amazon</a>
+      <a class="btn-secondary block w-full text-center" href="{{ book.page }}">{{ knw_btn }}</a>
     </div>
   </div>
 </div>

--- a/_includes/books.html
+++ b/_includes/books.html
@@ -9,7 +9,7 @@
 <div class="relative group">
 <div class="absolute -inset-1 rounded-2xl bg-gradient-to-r from-primary to-primary-fixed-dim opacity-10 blur transition duration-500 group-hover:opacity-20"></div>
 <a href="{{ item.permalink | relative_url }}" class="relative block rounded-2xl border border-outline-variant bg-surface-container-lowest p-3 shadow-lg dark:border-outline dark:bg-inverse-surface">
-<img class="w-full max-w-[400px] rounded-xl" src="{{ item.book_cover_ipad | relative_url }}" alt="{{ item.book_cover_ipad_alt }}">
+<img class="w-full max-w-[400px] rounded-xl" src="{{ item.book_cover_ipad | relative_url }}" alt="{{ item.book_cover_ipad_alt }}" loading="lazy" decoding="async" width="400" height="300">
 </a>
 </div>
 </div>

--- a/_includes/end-of-post-articles-cards.html
+++ b/_includes/end-of-post-articles-cards.html
@@ -2,7 +2,7 @@
   {% if post.tags.first %}
     <span class="font-label text-label-sm uppercase tracking-wider text-primary">{{ post.tags.first }}</span>
   {% endif %}
-  <h4 class="mt-2 font-display text-lg font-bold text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">{{ post.title }}</h4>
+  <h3 class="mt-2 font-display text-lg font-bold text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">{{ post.title }}</h3>
   <p class="mt-2 line-clamp-2 text-sm text-on-surface-variant dark:text-inverse-on-surface/70">
     {% if post.description %}
       {{ post.description }}

--- a/_includes/end-of-post-articles.html
+++ b/_includes/end-of-post-articles.html
@@ -1,8 +1,8 @@
 {% include language-detection.html %}
 {% if page.related %}
-  <h3 class="mb-8 font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">
+  <h2 class="mb-8 font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">
     {% if current_lang == "en" %}Related Articles{% else %}Artigos relacionados{% endif %}
-  </h3>
+  </h2>
   {% assign related_post_list = page.posts_list | join: ',' | split: ',' %}
   <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
     {% for related_post in related_post_list %}
@@ -15,9 +15,9 @@
     {% endfor %}
   </div>
 {% else %}
-  <h3 class="mb-8 font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">
+  <h2 class="mb-8 font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">
     {% if current_lang == "en" %}Recent Articles{% else %}Artigos recentes{% endif %}
-  </h3>
+  </h2>
   <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
     {% for post in site.related_posts limit:3 %}
       {% include end-of-post-articles-cards.html %}

--- a/_includes/fonts.html
+++ b/_includes/fonts.html
@@ -10,6 +10,11 @@
 <link rel="stylesheet" href="{{ text_fonts_url }}" media="print" onload="this.media='all'">
 <noscript><link rel="stylesheet" href="{{ text_fonts_url }}"></noscript>
 
-{% comment %} icon_names must be alphabetically sorted; FILL axis for filled play_arrow {% endcomment %}
-{% capture icon_fonts_url %}https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:FILL@0..1&icon_names=alternate_email,arrow_forward,arrow_right_alt,article,calendar_month,calendar_today,chevron_right,cloud,code,dark_mode,expand_more,forum,hub,language,library_books,light_mode,live_tv,mail,menu,menu_book,music_note,play_arrow,play_circle,public,school,shopping_bag,shopping_cart,timer,tips_and_updates,work&display=block{% endcapture %}
-<link rel="stylesheet" href="{{ icon_fonts_url }}">
+{% comment %}
+  icon_names must be alphabetically sorted; FILL axis for filled play_arrow.
+  display=optional avoids long icon-font blocking; ligature flash is rare with the
+  subset URL. Text fonts already use display=swap via the async print media pattern.
+{% endcomment %}
+{% capture icon_fonts_url %}https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:FILL@0..1&icon_names=alternate_email,arrow_forward,arrow_right_alt,article,calendar_month,calendar_today,chevron_right,cloud,code,dark_mode,expand_more,forum,hub,language,library_books,light_mode,live_tv,mail,menu,menu_book,music_note,play_arrow,play_circle,public,school,shopping_bag,shopping_cart,timer,tips_and_updates,work&display=optional{% endcapture %}
+<link rel="stylesheet" href="{{ icon_fonts_url }}" media="print" onload="this.media='all'">
+<noscript><link rel="stylesheet" href="{{ icon_fonts_url }}"></noscript>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,11 @@
 {% include language-detection.html %}
+{% if current_lang == "en" %}
+  {% assign home_url = '/en/' | relative_url %}
+{% elsif current_lang == "fr" %}
+  {% assign home_url = '/fr/' | relative_url %}
+{% else %}
+  {% assign home_url = '/' | relative_url %}
+{% endif %}
 
 <footer class="border-t border-outline-variant bg-surface-container-low py-16 dark:border-outline dark:bg-background-dark">
   <div class="site-container">
@@ -7,11 +14,11 @@
         {% if site.copyright.name %}
           {% if current_lang == "en" %}
             <p class="font-display text-lg text-on-surface-variant dark:text-inverse-on-surface">
-              All rights reserved by <a class="font-bold text-on-surface transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="{{ site.copyright.link }}" target="_blank" rel="noopener">{{ site.copyright.name }}</a>
+              All rights reserved by <a class="font-bold text-on-surface transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="{{ home_url }}">{{ site.copyright.name }}</a>
             </p>
           {% else %}
             <p class="font-display text-lg text-on-surface-variant dark:text-inverse-on-surface">
-              Todos os direitos reservados a <a class="font-bold text-on-surface transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="{{ site.copyright.link }}" target="_blank" rel="noopener">{{ site.copyright.name }}</a>
+              Todos os direitos reservados a <a class="font-bold text-on-surface transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="{{ home_url }}">{{ site.copyright.name }}</a>
             </p>
           {% endif %}
         {% endif %}
@@ -19,23 +26,25 @@
 
       <div class="flex items-center gap-6">
         {% if site.twitter.username %}
-          <a class="text-on-surface-variant transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="https://twitter.com/{{ site.twitter.username }}" target="_blank" rel="noopener" aria-label="Twitter">
-            <svg class="h-7 w-7" fill="currentColor" viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path></svg>
+          <a class="text-on-surface-variant transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="https://twitter.com/{{ site.twitter.username }}" target="_blank" rel="noopener noreferrer" aria-label="Jessica Temporal on X (Twitter)">
+            <svg class="h-7 w-7" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path></svg>
           </a>
         {% endif %}
         {% if site.github %}
-          <a class="text-on-surface-variant transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="{{ site.github }}" target="_blank" rel="noopener" aria-label="GitHub">
-            <svg class="h-7 w-7" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.026 2.747-1.026.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"></path></svg>
+          <a class="text-on-surface-variant transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="{{ site.github }}" target="_blank" rel="noopener noreferrer" aria-label="Jessica Temporal on GitHub">
+            <svg class="h-7 w-7" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.026 2.747-1.026.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"></path></svg>
           </a>
         {% endif %}
         {% if site.contact_form %}
           {% if current_lang == "en" %}
             {% assign contact_form_url = site.contact_form.en %}
+            {% assign contact_label = "Contact Jessica Temporal" %}
           {% else %}
             {% assign contact_form_url = site.contact_form.pt %}
+            {% assign contact_label = "Contatar Jessica Temporal" %}
           {% endif %}
-          <a class="text-on-surface-variant transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="{{ contact_form_url }}" target="_blank" rel="noopener" aria-label="Contact form">
-            <span class="material-symbols-outlined text-[28px]">mail</span>
+          <a class="text-on-surface-variant transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="{{ contact_form_url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ contact_label }}">
+            <span class="material-symbols-outlined text-[28px]" aria-hidden="true">mail</span>
           </a>
         {% endif %}
       </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,7 +18,7 @@
           {% assign base = "/sobre,/livros,/series-pt,/palestras,/videos,/sociais,/EnJtResume.pdf,https://gitfichas.com/?utm_source=blog" | split: ',' %}
         {% endif %}
 
-        <nav class="hidden items-center gap-6 md:flex">
+        <nav class="hidden items-center gap-6 md:flex" aria-label="Primary">
           {% for item in options %}
             {% assign idx = forloop.index0 %}
             <a class="font-sans text-base font-medium text-on-surface-variant transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="{{ base[idx] }}">{{ item }}</a>
@@ -30,16 +30,16 @@
         {% include language-switcher-multi.html %}
 
         <button id="theme-toggle" type="button" class="rounded-full p-2 text-on-surface-variant transition-colors hover:bg-surface-container dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle theme">
-          <span class="material-symbols-outlined text-xl" id="theme-icon">dark_mode</span>
+          <span class="material-symbols-outlined text-xl" id="theme-icon" aria-hidden="true">dark_mode</span>
         </button>
 
-        <button id="mobile-nav-toggle" type="button" class="rounded-full p-2 text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle navigation">
-          <span class="material-symbols-outlined text-xl">menu</span>
+        <button id="mobile-nav-toggle" type="button" class="rounded-full p-2 text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav-menu">
+          <span class="material-symbols-outlined text-xl" aria-hidden="true">menu</span>
         </button>
       </div>
     </div>
 
-    <nav id="mobile-nav-menu" class="hidden border-t border-outline-variant py-4 md:hidden dark:border-outline">
+    <nav id="mobile-nav-menu" class="hidden border-t border-outline-variant py-4 md:hidden dark:border-outline" aria-label="Mobile" hidden>
       <div class="flex flex-col gap-3">
         {% for item in options %}
           {% assign idx = forloop.index0 %}

--- a/_includes/home-book-banner.html
+++ b/_includes/home-book-banner.html
@@ -1,7 +1,11 @@
 {% include language-detection.html %}
 {% assign book = site.banner_books[current_lang].book %}
 {% assign buy = site.languages[current_lang].text.buy_button %}
-{% assign knw_btn = site.languages[current_lang].text.know_more_button %}
+{% if current_lang == "en" %}
+  {% assign knw_btn = "About " | append: book.title %}
+{% else %}
+  {% assign knw_btn = "Sobre " | append: book.title %}
+{% endif %}
 
 <section class="border-t border-outline-variant bg-surface-container-low py-24 dark:border-outline dark:bg-background-dark">
   <div class="site-container">

--- a/_includes/language-switcher-multi.html
+++ b/_includes/language-switcher-multi.html
@@ -3,10 +3,10 @@
 {% endcomment %}
 
 <div class="relative">
-  <button id="lang-menu-toggle" type="button" class="flex items-center gap-1 rounded-full bg-surface-container px-3 py-1.5 font-label text-sm font-medium text-on-surface transition-colors hover:bg-surface-container-high dark:bg-inverse-surface dark:text-inverse-on-surface dark:hover:bg-outline-variant">
-    <span class="material-symbols-outlined text-lg">language</span>
+  <button id="lang-menu-toggle" type="button" class="flex items-center gap-1 rounded-full bg-surface-container px-3 py-1.5 font-label text-sm font-medium text-on-surface transition-colors hover:bg-surface-container-high dark:bg-inverse-surface dark:text-inverse-on-surface dark:hover:bg-outline-variant" aria-label="Language: {{ current_lang_config.name }}" aria-haspopup="listbox" aria-expanded="false" aria-controls="lang-menu">
+    <span class="material-symbols-outlined text-lg" aria-hidden="true">language</span>
     <span>{{ current_lang_config.flag }} {{ current_lang_config.code | upcase }}</span>
-    <span class="material-symbols-outlined text-sm">expand_more</span>
+    <span class="material-symbols-outlined text-sm" aria-hidden="true">expand_more</span>
   </button>
 
   <div id="lang-menu" class="absolute right-0 z-50 mt-2 hidden min-w-[12rem] overflow-hidden rounded-xl border border-outline-variant bg-surface-container-lowest shadow-lg dark:border-outline dark:bg-inverse-surface">

--- a/_includes/lil-jess.html
+++ b/_includes/lil-jess.html
@@ -35,6 +35,9 @@
 
   #lil-jess .lj-char {
     position: relative;
+    /* 48px minimum touch target; visual stays the 76px avatar. */
+    min-width: 48px;
+    min-height: 48px;
     width: 76px;
     height: 76px;
     padding: 0;
@@ -69,19 +72,25 @@
     100% { transform: translateY(0) scale(1); }
   }
 
-  /* Anchored to the character so it leaves with her on dismiss. */
+  /*
+    Dismiss control: 44×44 hit target (WCAG 2.5.5 / Lighthouse),
+    placed above the avatar with ≥8px gap so targets don't collide.
+  */
   #lil-jess .lj-close {
     position: absolute;
-    /* .lj-char is 76px; pin the ✕ to its top-right corner. */
-    bottom: calc(76px - 0.25rem);
-    right: -0.25rem;
-    width: 22px;
-    height: 22px;
+    bottom: calc(76px + 10px);
+    right: 0;
+    width: 44px;
+    height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
     border: none;
     border-radius: 50%;
     background: rgba(0, 0, 0, 0.55);
     color: #fff;
-    font-size: 13px;
+    font-size: 22px;
     line-height: 1;
     cursor: pointer;
     opacity: 0;
@@ -92,9 +101,14 @@
   #lil-jess.lj-in .lj-close { transform: translateY(0); }
   #lil-jess.lj-in:hover .lj-close,
   #lil-jess.lj-in:focus-within .lj-close { opacity: 1; }
+  #lil-jess .lj-close:focus-visible {
+    opacity: 1;
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+  }
   /* Touch screens have no hover — keep the dismiss button visible while she's in. */
   @media (hover: none) {
-    #lil-jess.lj-in .lj-close { opacity: 0.85; }
+    #lil-jess.lj-in .lj-close { opacity: 0.9; }
   }
 
   #lil-jess .lj-confetti {

--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -5,9 +5,9 @@
       <p class="mb-2 font-sans text-xs font-semibold uppercase tracking-wider {% if post.lang == 'pt' %}text-primary{% else %}text-on-surface-variant{% endif %}">
         {{ post.date | date: "%b %-d, %Y" }}
       </p>
-      <h3 class="font-display text-headline-sm leading-tight text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">
+      <h2 class="font-display text-headline-sm leading-tight text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">
         {{ post.title }}{% if post.subtitle %}: {{ post.subtitle }}{% endif %}
-      </h3>
+      </h2>
       <p class="mt-3 line-clamp-2 font-sans text-body-md text-on-surface-variant dark:text-inverse-on-surface/70">
         {% if post.description %}
           {{ post.description }}

--- a/_includes/posthog.html
+++ b/_includes/posthog.html
@@ -1,14 +1,26 @@
 <script>
   (function () {
+    var loaded = false;
     function initPostHog() {
+      if (loaded) return;
+      loaded = true;
       !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
       posthog.init('{{ site.posthog }}', { api_host: 'https://us.i.posthog.com', person_profiles: 'identified_only' });
     }
 
-    if ('requestIdleCallback' in window) {
-      requestIdleCallback(initPostHog);
-    } else {
-      window.addEventListener('load', initPostHog);
+    function schedule() {
+      if ('requestIdleCallback' in window) {
+        requestIdleCallback(initPostHog, { timeout: 4000 });
+      } else {
+        window.addEventListener('load', function () {
+          setTimeout(initPostHog, 2000);
+        });
+      }
     }
+
+    ['pointerdown', 'keydown', 'scroll', 'touchstart'].forEach(function (evt) {
+      window.addEventListener(evt, initPostHog, { once: true, passive: true });
+    });
+    schedule();
   })();
 </script>

--- a/_includes/related-articles-widget.html
+++ b/_includes/related-articles-widget.html
@@ -4,7 +4,7 @@
 
 <div class="rounded-2xl border border-outline-variant bg-surface-container-low p-6 dark:border-outline dark:bg-inverse-surface">
   {% if page.related %}
-    <h3 class="mb-4 font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">{{ related_articles_title }}</h3>
+    <h2 class="mb-4 font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">{{ related_articles_title }}</h2>
     {% assign related_post_list = page.posts_list | join: ',' | split: ',' %}
     <ul class="space-y-3">
       {% for related_post in related_post_list %}
@@ -20,7 +20,7 @@
       {% endfor %}
     </ul>
   {% else %}
-    <h3 class="mb-4 font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">{{ recent_articles_title }}</h3>
+    <h2 class="mb-4 font-display text-headline-sm text-on-surface dark:text-inverse-on-surface">{{ recent_articles_title }}</h2>
     <ul class="space-y-3">
       {% for post in site.posts limit:3 %}
         <li>

--- a/_includes/series-logic.html
+++ b/_includes/series-logic.html
@@ -48,9 +48,9 @@
 
       <article class="group overflow-hidden rounded-2xl border border-outline-variant bg-surface-container-lowest shadow-cozy transition-all duration-500 hover:-translate-y-1 hover:shadow-xl dark:border-outline dark:bg-inverse-surface">
         <a class="block p-6 no-underline" href="{{ series_base }}/{{ series | slugify }}/">
-          <h3 class="font-display text-headline-sm text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">
+          <h2 class="font-display text-headline-sm text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">
             {{ series }}
-          </h3>
+          </h2>
           <p class="mt-2 font-label text-label-sm uppercase tracking-wider text-on-surface-variant">
             {% if current_lang == "en" %}{{ series_posts.size }} posts in this series{% else %}{{ series_posts.size }} posts nesta série{% endif %}
           </p>

--- a/_includes/series-widget.html
+++ b/_includes/series-widget.html
@@ -7,7 +7,7 @@
         <span class="material-symbols-outlined">library_books</span>
       </div>
       <div>
-        <h3 class="font-display font-bold text-on-surface dark:text-inverse-on-surface">{% if current_lang == "en" %}Series{% else %}Série{% endif %}</h3>
+        <h2 class="font-display font-bold text-on-surface dark:text-inverse-on-surface">{% if current_lang == "en" %}Series{% else %}Série{% endif %}</h2>
         <p class="font-label text-label-sm uppercase tracking-wider text-primary">{{ page.series }}</p>
       </div>
     </div>

--- a/_includes/socials-logic.html
+++ b/_includes/socials-logic.html
@@ -5,7 +5,7 @@
     <a class="group flex items-center justify-between py-6 no-underline transition-all duration-300 hover:pl-4" href="{{ social.url }}" target="_blank" rel="noopener noreferrer">
       <div class="flex items-center gap-6">
         <span class="material-symbols-outlined text-3xl text-on-surface-variant transition-colors group-hover:text-primary dark:text-inverse-on-surface/70">{{ social.icon }}</span>
-        <h3 class="font-display text-headline-sm text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">{{ social.name }}</h3>
+        <h2 class="font-display text-headline-sm text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">{{ social.name }}</h2>
       </div>
       <span class="material-symbols-outlined text-primary opacity-0 transition-all group-hover:translate-x-2 group-hover:opacity-100">arrow_forward</span>
     </a>
@@ -21,7 +21,7 @@
     <a class="group flex items-center justify-between py-6 no-underline transition-all duration-300 hover:pl-4" href="{{ contact_form_url }}" target="_blank" rel="noopener noreferrer">
       <div class="flex items-center gap-6">
         <span class="material-symbols-outlined text-3xl text-on-surface-variant transition-colors group-hover:text-primary dark:text-inverse-on-surface/70">mail</span>
-        <h3 class="font-display text-headline-sm text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">{{ contact_form_name }}</h3>
+        <h2 class="font-display text-headline-sm text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">{{ contact_form_name }}</h2>
       </div>
       <span class="material-symbols-outlined text-primary opacity-0 transition-all group-hover:translate-x-2 group-hover:opacity-100">arrow_forward</span>
     </a>

--- a/_includes/talks-logic.html
+++ b/_includes/talks-logic.html
@@ -64,8 +64,8 @@
             <p class="mt-2 font-sans text-body-md text-on-surface-variant dark:text-inverse-on-surface/70">{{ post.description }}</p>
           {% endif %}
         </div>
-        <a class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-outline-variant text-on-surface-variant no-underline transition-all hover:border-primary hover:bg-primary hover:text-on-primary dark:border-outline dark:text-inverse-on-surface" href="{{ post.url | relative_url }}" aria-label="View talk">
-          <span class="material-symbols-outlined text-[20px]">arrow_forward</span>
+        <a class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-outline-variant text-on-surface-variant no-underline transition-all hover:border-primary hover:bg-primary hover:text-on-primary dark:border-outline dark:text-inverse-on-surface" href="{{ post.url | relative_url }}" aria-label="{% if current_lang == 'en' %}View talk: {% elsif current_lang == 'fr' %}Voir la conférence : {% else %}Ver palestra: {% endif %}{{ post.title }}">
+          <span class="material-symbols-outlined text-[20px]" aria-hidden="true">arrow_forward</span>
         </a>
       </div>
     {% endif %}

--- a/_includes/video-card.html
+++ b/_includes/video-card.html
@@ -6,9 +6,9 @@
     {% include post-tag-banner.html post=post %}
     <div class="flex flex-1 flex-col justify-between p-6">
       <div>
-        <h3 class="font-display text-headline-sm leading-tight text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">
+        <h2 class="font-display text-headline-sm leading-tight text-on-surface transition-colors group-hover:text-primary dark:text-inverse-on-surface">
           {{ post.title }}
-        </h3>
+        </h2>
         <p class="mt-2 font-label text-label-sm uppercase tracking-wider text-on-surface-variant">
           {{ post.date | date: "%b %-d, %Y" }}
         </p>

--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -30,9 +30,9 @@ layout: default
         <div class="mt-8 space-y-6">
           {% for post in series_posts %}
             <div class="ink-card-hover rounded-2xl border border-outline-variant p-6 dark:border-outline">
-              <h3 class="font-display text-headline-sm">
+              <h2 class="font-display text-headline-sm">
                 <a class="text-on-surface transition-colors hover:text-primary dark:text-inverse-on-surface dark:hover:text-inverse-primary" href="{{ post.url | prepend: site.url }}">{{ post.title }}</a>
-              </h3>
+              </h2>
               {% if post.description %}
                 <p class="mt-2 text-on-surface-variant dark:text-inverse-on-surface/70">{{ post.description }}</p>
               {% else %}

--- a/assets/js/mobile-nav.js
+++ b/assets/js/mobile-nav.js
@@ -4,20 +4,41 @@
   const langToggle = document.getElementById('lang-menu-toggle');
   const langMenu = document.getElementById('lang-menu');
 
+  function setMenuOpen(open) {
+    if (!toggle || !menu) return;
+    menu.classList.toggle('hidden', !open);
+    if (open) {
+      menu.removeAttribute('hidden');
+    } else {
+      menu.setAttribute('hidden', '');
+    }
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+  }
+
   if (toggle && menu) {
+    // Keep HTML hidden attribute in sync with the Tailwind "hidden" class.
+    setMenuOpen(false);
+
     toggle.addEventListener('click', function () {
-      menu.classList.toggle('hidden');
+      setMenuOpen(menu.hasAttribute('hidden'));
     });
   }
 
   if (langToggle && langMenu) {
+    function setLangOpen(open) {
+      langMenu.classList.toggle('hidden', !open);
+      langToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+
+    setLangOpen(false);
+
     langToggle.addEventListener('click', function () {
-      langMenu.classList.toggle('hidden');
+      setLangOpen(langMenu.classList.contains('hidden'));
     });
 
     document.addEventListener('click', function (event) {
       if (!langToggle.contains(event.target) && !langMenu.contains(event.target)) {
-        langMenu.classList.add('hidden');
+        setLangOpen(false);
       }
     });
   }

--- a/index.html
+++ b/index.html
@@ -17,13 +17,16 @@ image: "/images/logo.webp"
   </div>
 
   {% if paginator.total_pages > 1 %}
+    {% include language-detection.html %}
+    {% assign prev_label = site.languages[current_lang].text.previous_page | default: "Previous page" %}
+    {% assign next_label = site.languages[current_lang].text.next_page | default: "Next page" %}
     <nav class="mt-16 flex items-center justify-center gap-4" aria-label="Pagination">
       {% if paginator.previous_page %}
-        <a class="rounded-full border border-outline-variant px-4 py-2 font-label text-sm transition-colors hover:border-primary hover:text-primary dark:border-outline" href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">Previous</a>
+        <a class="rounded-full border border-outline-variant px-4 py-2 font-label text-sm transition-colors hover:border-primary hover:text-primary dark:border-outline" href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" aria-label="{{ prev_label }}">{{ prev_label }}</a>
       {% endif %}
       <span class="font-label text-sm text-on-surface-variant">Page {{ paginator.page }} of {{ paginator.total_pages }}</span>
       {% if paginator.next_page %}
-        <a class="rounded-full border border-outline-variant px-4 py-2 font-label text-sm transition-colors hover:border-primary hover:text-primary dark:border-outline" href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Next</a>
+        <a class="rounded-full border border-outline-variant px-4 py-2 font-label text-sm transition-colors hover:border-primary hover:text-primary dark:border-outline" href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}" aria-label="{{ next_label }}">{{ next_label }}</a>
       {% endif %}
     </nav>
   {% endif %}

--- a/netlify.toml
+++ b/netlify.toml
@@ -42,14 +42,29 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     X-XSS-Protection = "1; mode=block"
 
-# Enable compression for HTML, CSS, JS
+# HTML/pages: short revalidate cache. Clean URLs (no .html) need an explicit rule.
 [[headers]]
   for = "*.html"
   [headers.values]
-    Cache-Control = "public, max-age=3600"
+    Cache-Control = "public, max-age=600, must-revalidate"
+
+[[headers]]
+  for = "/"
+  [headers.values]
+    Cache-Control = "public, max-age=600, must-revalidate"
+
+[[headers]]
+  for = "/page*"
+  [headers.values]
+    Cache-Control = "public, max-age=600, must-revalidate"
 
 [[headers]]
   for = "/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/js/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
 
@@ -62,6 +77,16 @@
   for = "*.js"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "*.woff2"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "*.webp"
+  [headers.values]
+    Cache-Control = "public, max-age=7776000"
 
 [[headers]]
   for = "/favicon.ico"


### PR DESCRIPTION
## Summary

Closes #2. Follow-up polish after the earlier PageSpeed wins (Perf 92 / A11y 98 / SEO 92).

- **SEO:** Replace non-descriptive `Learn more` / bare `Next` with book-specific and pagination labels so the homepage can return to SEO 100.
- **Accessibility:** Fix heading hierarchy skips (h1→h3) on listing, book FAQ, related posts, and sidebar widgets; align footer/home links; improve mobile nav and icon/talk link labels.
- **Performance:** Defer GA4 and PostHog until idle/interaction; non-block Material Symbols (`display=optional`); tighten Netlify cache headers for pages and static assets.

## Commits

1. Improve SEO link text for book CTAs and pagination
2. Fix heading hierarchy skips across listing and post pages
3. Harden navigation link purpose and mobile menu accessibility
4. Defer analytics and polish font/cache performance headers

## Test plan

- [x] Local Jekyll preview (`_dev_config.yml`): `/`, `/page2/`, book EN/PT, series, talks, videos, socials, sample post
- [x] No `Learn more` / bare `Next` on homepage; CTAs and pagination descriptive
- [x] No heading level skips on checked pages
- [x] Header/footer home links match; mobile nav `hidden` + `aria-expanded` toggle
- [x] Talks arrow links use `View talk: <title>`
- [x] Production build includes deferred analytics + `display=optional` icons
- [ ] After deploy: PageSpeed Insights on https://jtemporal.com/ (desktop) — Perf ≥ 90, A11y → 100, SEO → 100

Note: GA/PostHog payload size remains third-party once loaded; full unused-JS savings would require dropping a tracker.