### PR TITLE
Embed YouTube video “How to Undo Commits in Git” in related posts

### DIFF
--- a/_posts/2022/2022-01-14-desfazendo-um-ou-mais-commits.md
+++ b/_posts/2022/2022-01-14-desfazendo-um-ou-mais-commits.md
@@ -29,7 +29,7 @@ Como tudo que fazemos em git pode ser feito de inúmeras formas diferentes, exis
 Prefere assistir? Aqui vai um vídeo sobre o mesmo tema:
 
 <center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </center>
 
 ## O que é o HEAD?

--- a/_posts/2022/2022-01-14-desfazendo-um-ou-mais-commits.md
+++ b/_posts/2022/2022-01-14-desfazendo-um-ou-mais-commits.md
@@ -26,6 +26,12 @@ type: post
 
 Como tudo que fazemos em git pode ser feito de inúmeras formas diferentes, existem alguns jeitos de se livrar de commits, a forma mais comum de desfazer um ou mais commits recentes é usando o comando `git reset` que vou te mostrar nessa colinha.
 
+Prefere assistir? Aqui vai um vídeo sobre o mesmo tema:
+
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
+
 ## O que é o HEAD?
 
 O `HEAD` é um ponteiro que indica qual branch e commit você está. Ele é usado com frequência e muitas vezes sem você mesmo saber que ele é acessado para trocar de branches por exemplo.

--- a/_posts/2022/2022-01-14-undoing-the-last-commits-using-git-reset.md
+++ b/_posts/2022/2022-01-14-undoing-the-last-commits-using-git-reset.md
@@ -32,7 +32,7 @@ Since everything we do in git can be done in countless different ways, there are
 Prefer watching? Here’s a walkthrough of the same topic:
 
 <center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </center>
 
 ## What is the HEAD?

--- a/_posts/2022/2022-01-14-undoing-the-last-commits-using-git-reset.md
+++ b/_posts/2022/2022-01-14-undoing-the-last-commits-using-git-reset.md
@@ -29,6 +29,12 @@ author_note: true
 
 Since everything we do in git can be done in countless different ways, there are a few ways to get rid of commits. The most common way to undo one or more recent commits is using the command `git reset` that you'll see in this pro tip.
 
+Prefer watching? Here’s a walkthrough of the same topic:
+
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
+
 ## What is the HEAD?
 
 `HEAD` is a pointer that indicates which branch and commit you’re on. It is used frequently, and often without you even knowing it. For example, did you know the `HEAD` is used to switch branches?

--- a/_posts/2022/2022-01-15-desfazendo-o-ultimo-commit-e-reaproveitando-a-mensagem.md
+++ b/_posts/2022/2022-01-15-desfazendo-o-ultimo-commit-e-reaproveitando-a-mensagem.md
@@ -37,7 +37,7 @@ Com esses dois comandos no seu repertório de comandos Git você será muito mai
 Prefere assistir? Aqui vai um vídeo sobre o mesmo tema:
 
 <center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </center>
 
 ## Criando o cenário

--- a/_posts/2022/2022-01-15-desfazendo-o-ultimo-commit-e-reaproveitando-a-mensagem.md
+++ b/_posts/2022/2022-01-15-desfazendo-o-ultimo-commit-e-reaproveitando-a-mensagem.md
@@ -34,6 +34,12 @@ Desfazer e refazer commits faz parte do dia a dia, então é importante entender
 
 Com esses dois comandos no seu repertório de comandos Git você será muito mais feliz. 😉
 
+Prefere assistir? Aqui vai um vídeo sobre o mesmo tema:
+
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
+
 ## Criando o cenário
 
 Eu falei sobre o comando [`git reset` nesta outra colinha](https://jtemporal.com/desfazendo-um-ou-mais-commits), em resumo ele é um comando que permite retornar à um estado anterior. O uso mais básico deste comando é usá-lo para desfazer um ou mais commits dos mais recentes. Com isso, vamos supor que você está na seguinte situação (curiosamente eu passei por isso na última sexta):

--- a/_posts/2022/2022-01-15-undoing-the-last-commit-and-reusing-the-message.md
+++ b/_posts/2022/2022-01-15-undoing-the-last-commit-and-reusing-the-message.md
@@ -36,6 +36,12 @@ Undoing and redoing commits is part of everyday life, so it is important to unde
 
 With these two commands in your repertoire of Git commands, you will be way happier. 😉
 
+Prefer watching? Here’s a walkthrough of the same topic:
+
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
+
 ## Creating the scenario
 
 I talked about the command [`git reset` in this other pro tip](https://jtemporal.com/undoing-the-last-commits-using-git-reset). In a nutshell, it is a command that allows you to return to a previous state. The most basic use of this command is to use it to undo one or more of the most recent commits. With that, let's assume you're in the following situation (interestingly I went through this last Friday):

--- a/_posts/2022/2022-01-15-undoing-the-last-commit-and-reusing-the-message.md
+++ b/_posts/2022/2022-01-15-undoing-the-last-commit-and-reusing-the-message.md
@@ -39,7 +39,7 @@ With these two commands in your repertoire of Git commands, you will be way happ
 Prefer watching? Here’s a walkthrough of the same topic:
 
 <center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </center>
 
 ## Creating the scenario

--- a/_posts/2023/2023-11-30-como-desfazer-alteracoes-em-um-repositorio-git-usando-git-revert.md
+++ b/_posts/2023/2023-11-30-como-desfazer-alteracoes-em-um-repositorio-git-usando-git-revert.md
@@ -32,7 +32,7 @@ Existem várias maneiras de desfazer commits. Nesta colinha, você vai aprender 
 Prefere assistir? Aqui vai um vídeo sobre o mesmo tema:
 
 <center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </center>
 
 ## O que é git revert?

--- a/_posts/2023/2023-11-30-como-desfazer-alteracoes-em-um-repositorio-git-usando-git-revert.md
+++ b/_posts/2023/2023-11-30-como-desfazer-alteracoes-em-um-repositorio-git-usando-git-revert.md
@@ -29,6 +29,12 @@ author_note: false
 
 Existem várias maneiras de desfazer commits. Nesta colinha, você vai aprender como usar o `git revert` para desfazer commits, especialmente quando eles já foram publicados.
 
+Prefere assistir? Aqui vai um vídeo sobre o mesmo tema:
+
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
+
 ## O que é git revert?
 
 `git revert` é um comando que desfaz uma alteração de um commit executando duas ações:

--- a/_posts/2023/2023-11-30-how-to-undo-changes-in-a-git-repository-using-git-revert.md
+++ b/_posts/2023/2023-11-30-how-to-undo-changes-in-a-git-repository-using-git-revert.md
@@ -31,7 +31,7 @@ There are a number of ways of undoing commits in this pro-tip you will learn how
 Prefer watching? Here’s a walkthrough of the same topic:
 
 <center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </center>
 
 ## What is git revert?

--- a/_posts/2023/2023-11-30-how-to-undo-changes-in-a-git-repository-using-git-revert.md
+++ b/_posts/2023/2023-11-30-how-to-undo-changes-in-a-git-repository-using-git-revert.md
@@ -28,6 +28,12 @@ author_note: false
 ---
 There are a number of ways of undoing commits in this pro-tip you will learn how to use `git revert` to undo commits specially when they already been published.
 
+Prefer watching? Here’s a walkthrough of the same topic:
+
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
+
 ## What is git revert?
 
 `git revert` is a command that will undo a change in a commit by performing two actions:

--- a/_posts/2026-06-28-desfazendo-mais-de-um-commit-de-uma-vez-com-git-revert.md
+++ b/_posts/2026-06-28-desfazendo-mais-de-um-commit-de-uma-vez-com-git-revert.md
@@ -26,6 +26,12 @@ translations:
 
 Você talvez já saiba como usar `git revert` para reverter um único commit, mas você também pode reverter um intervalo de commits com um único comando. Nesta dica rápida, você vai aprender como.
 
+Prefere assistir? Aqui vai um vídeo sobre o mesmo tema:
+
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
+
 ## Revertendo um commit
 
 Você pode desfazer as mudanças de um commit específico criando um novo commit com `git revert`, passando o hash do commit:

--- a/_posts/2026-06-28-desfazendo-mais-de-um-commit-de-uma-vez-com-git-revert.md
+++ b/_posts/2026-06-28-desfazendo-mais-de-um-commit-de-uma-vez-com-git-revert.md
@@ -29,7 +29,7 @@ Você talvez já saiba como usar `git revert` para reverter um único commit, ma
 Prefere assistir? Aqui vai um vídeo sobre o mesmo tema:
 
 <center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </center>
 
 ## Revertendo um commit

--- a/_posts/2026-06-28-undoing-more-than-one-commit-at-once-with-git-revert.md
+++ b/_posts/2026-06-28-undoing-more-than-one-commit-at-once-with-git-revert.md
@@ -29,7 +29,7 @@ You may already know how to use `git revert` to reverse a single commit, but you
 Prefer watching? Here’s a walkthrough of the same topic:
 
 <center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </center>
 
 ## Reverting one commit

--- a/_posts/2026-06-28-undoing-more-than-one-commit-at-once-with-git-revert.md
+++ b/_posts/2026-06-28-undoing-more-than-one-commit-at-once-with-git-revert.md
@@ -26,6 +26,12 @@ translations:
 
 You may already know how to use `git revert` to reverse a single commit, but you can also revert a range of commits with a single command. In this pro tip, you'll learn how.
 
+Prefer watching? Here’s a walkthrough of the same topic:
+
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
+
 ## Reverting one commit
 
 You can reverse the changes in a given commit by creating a new commit with `git revert`, passing the commit hash:


### PR DESCRIPTION
Adds the YouTube embed for **How to Undo Commits in Git** (`https://youtu.be/hRNHGHWrNNA`) to the main posts about undoing commits.

### Posts updated (EN + PT)

| Post | Language |
|------|----------|
| Undoing the last commits using git reset | EN |
| Desfazendo os últimos commits usando git reset | PT |
| Undoing the last commit and keeping the changes for a next commit | EN |
| Desfazendo o último commit e mantendo as alterações… | PT |
| How to undo changes in a Git repository using git revert | EN |
| Como desfazer alterações… usando git revert | PT |
| Undoing more than one commit at once with git revert | EN |
| Desfazendo mais de um commit de uma vez com git revert | PT |

The embed is placed right after the introductory paragraph (before the first `##` heading), matching the pattern already used in the short-video posts.

```html
<center>
<iframe width="560" height="315" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
</center>
```

No other content was changed.