### PR TITLE
Add July 2026 Git tip Shorts as video posts

### DIFF
--- a/_posts/2026-07-14-git-rebase-onto-short.md
+++ b/_posts/2026-07-14-git-rebase-onto-short.md
@@ -42,8 +42,8 @@ The one rule with this command is that you always want to name the three branche
 
 Want the full walkthrough with diagrams? I covered it here: [Fixing the branch source with git rebase](/fixing-the-branch-source-with-git-rebase/)
 
-<div class="video-embed">
-<iframe src="https://www.youtube.com/embed/gonfHBYurhA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
+<center>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/gonfHBYurhA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
 
 Follow along for more git tips like this!

--- a/_posts/2026-07-14-git-rebase-onto-short.md
+++ b/_posts/2026-07-14-git-rebase-onto-short.md
@@ -42,8 +42,8 @@ The one rule with this command is that you always want to name the three branche
 
 Want the full walkthrough with diagrams? I covered it here: [Fixing the branch source with git rebase](/fixing-the-branch-source-with-git-rebase/)
 
-<center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/gonfHBYurhA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</center>
+<div class="video-embed">
+<iframe src="https://www.youtube.com/embed/gonfHBYurhA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
 
 Follow along for more git tips like this!

--- a/_posts/2026-07-14-git-rebase-onto-short.md
+++ b/_posts/2026-07-14-git-rebase-onto-short.md
@@ -1,0 +1,49 @@
+---
+layout: post
+type: video
+title: "Fix a branch you made from the wrong place with git rebase --onto"
+date: 2026-07-14 00:00:00 -0300
+last_modified_at: 2026-07-14
+hidden: true
+lang: en
+image: /images/covers/pro_tip.webp
+tags:
+- english
+- git
+- pro_tip
+- short
+description: Accidentally branched off the wrong branch? Use git rebase --onto to move just your commits to the right source.
+related: true
+posts_list:
+- fixing-the-branch-source-with-git-rebase
+- updating-a-branch-with-git-rebase
+- undoing-more-than-one-commit-at-once-with-git-revert
+---
+
+You accidentally branched off from the wrong branch. How do you fix the source?
+
+Say you meant to branch off of `main`, but you accidentally branched off from `task-1` instead. So now `task-2`, your new branch, has the wrong base.
+
+`git rebase --onto` can be pretty handy in these situations.
+
+You use `git rebase --onto` and give it three branches:
+
+1. `main` — the branch you wanted from the beginning
+2. `task-1` — the wrong branch you used
+3. `task-2` — the branch you want to fix the base of
+
+```console
+git rebase --onto main task-1 task-2
+```
+
+Git replays your `task-2` commits on top of `main`. That way `task-2` continues to be your branch, but it has the right base.
+
+The one rule with this command is that you always want to name the three branches to avoid dropping commits.
+
+Want the full walkthrough with diagrams? I covered it here: [Fixing the branch source with git rebase](/fixing-the-branch-source-with-git-rebase/)
+
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/gonfHBYurhA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
+
+Follow along for more git tips like this!

--- a/_posts/2026-07-16-git-stash-stack-short.md
+++ b/_posts/2026-07-16-git-stash-stack-short.md
@@ -34,8 +34,8 @@ Because stash works in the fashion of a stack, the last one in is always the fir
 
 Want the full stash workflow (pop, apply, and drop)? I covered it here: [Using git stash: pop, apply, and drop](/using-git-stash-and-git-stash-pop/)
 
-<div class="video-embed">
-<iframe src="https://www.youtube.com/embed/0c9d5e8NgH4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
+<center>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/0c9d5e8NgH4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
 
 Follow along for more git tips like this!

--- a/_posts/2026-07-16-git-stash-stack-short.md
+++ b/_posts/2026-07-16-git-stash-stack-short.md
@@ -1,0 +1,41 @@
+---
+layout: post
+type: video
+title: "Your Git stashes live in a stack"
+date: 2026-07-16 00:00:00 -0300
+last_modified_at: 2026-07-16
+hidden: true
+lang: en
+image: /images/covers/pro_tip.webp
+tags:
+- english
+- git
+- pro_tip
+- short
+description: Git stashes pile up like a stack — newest is always stash@{0}, and git stash pop grabs that one first.
+related: true
+posts_list:
+- using-git-stash-and-git-stash-pop
+- why-the-git-stash-drop-is-useful
+- git-stash-pop-vs-apply-short
+---
+
+Did you know that Git stashes get piled up on top of each other like in a stack?
+
+That means that every time you stash, Git bundles up all of the changes and puts them on top of the old stashes you already had.
+
+If you run `git stash list`, you can see all of your stashes. And every single one of them has an index.
+
+The new stash always on top will always have the index zero. And then one, two, three, and going back until you finish the stack.
+
+That also means that when you do `git stash pop` without picking any specific stash, Git will use the latest one — always the stash of index zero.
+
+Because stash works in the fashion of a stack, the last one in is always the first one out. And this is good to know, especially if you have more than one stash going.
+
+Want the full stash workflow (pop, apply, and drop)? I covered it here: [Using git stash: pop, apply, and drop](/using-git-stash-and-git-stash-pop/)
+
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/0c9d5e8NgH4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
+
+Follow along for more git tips like this!

--- a/_posts/2026-07-16-git-stash-stack-short.md
+++ b/_posts/2026-07-16-git-stash-stack-short.md
@@ -34,8 +34,8 @@ Because stash works in the fashion of a stack, the last one in is always the fir
 
 Want the full stash workflow (pop, apply, and drop)? I covered it here: [Using git stash: pop, apply, and drop](/using-git-stash-and-git-stash-pop/)
 
-<center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/0c9d5e8NgH4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</center>
+<div class="video-embed">
+<iframe src="https://www.youtube.com/embed/0c9d5e8NgH4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
 
 Follow along for more git tips like this!

--- a/_posts/2026-07-21-git-empty-commit-short.md
+++ b/_posts/2026-07-21-git-empty-commit-short.md
@@ -16,7 +16,6 @@ description: Need to force a rebuild of your GitHub Pages site? Create an empty 
 related: true
 posts_list:
 - force-rebuild-jekyll-en
-- using-empty-commits-to-rebuild-github-pages-websites
 ---
 
 Normally, Git doesn't let you just commit nothing. But if you use the `--allow-empty` flag, it will.
@@ -33,8 +32,8 @@ It creates a real commit for you, but without any changes in it. Think of it lik
 
 Want the full write-up? I covered empty commits for GitHub Pages rebuilds here: [Using empty commits to rebuild GitHub Pages websites](/force-rebuild-jekyll-en/)
 
-<center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/qvALqmgTiN8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</center>
+<div class="video-embed">
+<iframe src="https://www.youtube.com/embed/qvALqmgTiN8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
 
 Follow along for more git tips like this!

--- a/_posts/2026-07-21-git-empty-commit-short.md
+++ b/_posts/2026-07-21-git-empty-commit-short.md
@@ -1,0 +1,40 @@
+---
+layout: post
+type: video
+title: "Force a repo rebuild with an empty commit"
+date: 2026-07-21 00:00:00 -0300
+last_modified_at: 2026-07-21
+hidden: true
+lang: en
+image: /images/covers/pro_tip.webp
+tags:
+- english
+- git
+- pro_tip
+- short
+description: Need to force a rebuild of your GitHub Pages site? Create an empty commit with --allow-empty.
+related: true
+posts_list:
+- force-rebuild-jekyll-en
+- using-empty-commits-to-rebuild-github-pages-websites
+---
+
+Normally, Git doesn't let you just commit nothing. But if you use the `--allow-empty` flag, it will.
+
+Sometimes you need to force the rebuild of your repo (for example a GitHub Pages / Jekyll site that isn't picking up changes), and this is a clean way to do it without making up fake file changes.
+
+Simply run:
+
+```console
+git commit --allow-empty -m "Forcing website rebuild"
+```
+
+It creates a real commit for you, but without any changes in it. Think of it like a little nudge for your build to actually go through.
+
+Want the full write-up? I covered empty commits for GitHub Pages rebuilds here: [Using empty commits to rebuild GitHub Pages websites](/force-rebuild-jekyll-en/)
+
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/qvALqmgTiN8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
+
+Follow along for more git tips like this!

--- a/_posts/2026-07-21-git-empty-commit-short.md
+++ b/_posts/2026-07-21-git-empty-commit-short.md
@@ -32,8 +32,8 @@ It creates a real commit for you, but without any changes in it. Think of it lik
 
 Want the full write-up? I covered empty commits for GitHub Pages rebuilds here: [Using empty commits to rebuild GitHub Pages websites](/force-rebuild-jekyll-en/)
 
-<div class="video-embed">
-<iframe src="https://www.youtube.com/embed/qvALqmgTiN8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
+<center>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/qvALqmgTiN8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
 
 Follow along for more git tips like this!

--- a/_posts/2026-07-23-git-stash-drop-short.md
+++ b/_posts/2026-07-23-git-stash-drop-short.md
@@ -36,8 +36,8 @@ If you don't pass an index, it drops the most recent one (`stash@{0}`).
 
 Want the full explanation with examples? I covered it here: [Learn why the command git stash drop is useful](/why-the-git-stash-drop-is-useful/)
 
-<center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/LJFSLq_NnYc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</center>
+<div class="video-embed">
+<iframe src="https://www.youtube.com/embed/LJFSLq_NnYc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
 
 Follow along for more git tips like this!

--- a/_posts/2026-07-23-git-stash-drop-short.md
+++ b/_posts/2026-07-23-git-stash-drop-short.md
@@ -36,8 +36,8 @@ If you don't pass an index, it drops the most recent one (`stash@{0}`).
 
 Want the full explanation with examples? I covered it here: [Learn why the command git stash drop is useful](/why-the-git-stash-drop-is-useful/)
 
-<div class="video-embed">
-<iframe src="https://www.youtube.com/embed/LJFSLq_NnYc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
+<center>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/LJFSLq_NnYc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
 
 Follow along for more git tips like this!

--- a/_posts/2026-07-23-git-stash-drop-short.md
+++ b/_posts/2026-07-23-git-stash-drop-short.md
@@ -1,0 +1,43 @@
+---
+layout: post
+type: video
+title: "Clean up your Git stash list with git stash drop"
+date: 2026-07-23 00:00:00 -0300
+last_modified_at: 2026-07-23
+hidden: true
+lang: en
+image: /images/covers/pro_tip.webp
+tags:
+- english
+- git
+- pro_tip
+- short
+description: Old stashes pile up and cause conflict headaches. Use git stash drop to keep your stash list clean.
+related: true
+posts_list:
+- why-the-git-stash-drop-is-useful
+- using-git-stash-and-git-stash-pop
+- git-stash-stack-short
+---
+
+If you like to use stash just to keep your workspace clean, you should learn how to drop them.
+
+A stack of old stashes is a recipe for conflicts later. So it's always a good measure to maintain that stash list clean.
+
+When you are done with a stash, make sure to use `git stash drop`.
+
+If you want to drop a specific stash, you can always use the curly brackets notation to reference it:
+
+```console
+git stash drop stash@{1}
+```
+
+If you don't pass an index, it drops the most recent one (`stash@{0}`).
+
+Want the full explanation with examples? I covered it here: [Learn why the command git stash drop is useful](/why-the-git-stash-drop-is-useful/)
+
+<center>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/LJFSLq_NnYc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
+
+Follow along for more git tips like this!

--- a/_posts/2026-07-30-git-reset-vs-revert-short.md
+++ b/_posts/2026-07-30-git-reset-vs-revert-short.md
@@ -31,8 +31,8 @@ Rule of thumb: if you pushed it, revert. If it's still local, reset.
 
 Want the full breakdown (soft / mixed / hard reset, revert by hash, and the reflog safety net)? Watch the full video: [Undo Anything in Git](/undo-anything-in-git-reset-vs-revert/)
 
-<div class="video-embed">
-<iframe src="https://www.youtube.com/embed/tEjXP1m6gJM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
+<center>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/tEjXP1m6gJM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
 
 Follow along for more git tips like this!

--- a/_posts/2026-07-30-git-reset-vs-revert-short.md
+++ b/_posts/2026-07-30-git-reset-vs-revert-short.md
@@ -1,0 +1,38 @@
+---
+layout: post
+type: video
+title: "Git reset or git revert: which one should you use?"
+date: 2026-07-30 00:00:00 -0300
+last_modified_at: 2026-07-30
+hidden: true
+lang: en
+image: /images/covers/pro_tip.webp
+tags:
+- english
+- git
+- pro_tip
+- short
+description: Reset and revert both undo commits, but they are for different situations. Ask one question: did you already push?
+related: true
+posts_list:
+- undoing-more-than-one-commit-at-once-with-git-revert
+- recovering-lost-commits-with-git-reflog
+- undoing-the-last-commits-using-git-reset
+---
+
+Git reset or git revert. They sound the same, but they're intended for very different purposes.
+
+Ask one question: **Did you already push it?**
+
+- If the changes are still on your machine, use **reset**.
+- If you already shared them with your team, use **revert**, which walks back the changes safely with a new commit instead of rewriting history everyone already has.
+
+Rule of thumb: if you pushed it, revert. If it's still local, reset.
+
+Want the full breakdown (soft / mixed / hard reset, revert by hash, and the reflog safety net)? Watch the full video: [Undo Anything in Git](/undo-anything-in-git-reset-vs-revert/)
+
+<div class="video-embed">
+<iframe src="https://www.youtube.com/embed/tEjXP1m6gJM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+Follow along for more git tips like this!

--- a/_posts/2026-07-30-undo-anything-in-git-reset-vs-revert.md
+++ b/_posts/2026-07-30-undo-anything-in-git-reset-vs-revert.md
@@ -1,0 +1,143 @@
+---
+layout: post
+type: post
+bookbanner: true
+comments: true
+date: 2026-07-30 12:00:00 +00:00
+last_modified_at: 2026-07-30
+description: Learn how to undo any commit in Git with reset, revert, and reflog — without losing your work.
+image: /images/covers/pro_tip.webp
+lang: en
+related: true
+posts_list:
+- recovering-lost-commits-with-git-reflog
+- undoing-more-than-one-commit-at-once-with-git-revert
+- undoing-the-last-commits-using-git-reset
+series: "Git Pro Tips"
+tags:
+- git
+- english
+- pro_tip
+title: "Undo anything in Git: reset vs revert, explained"
+---
+
+Your coding assistant just made five commits, and one of them broke everything. Or maybe that was you at 2:00 AM. Either way, by the end of this post you'll know how to undo any commit in Git without losing your work.
+
+Undoing a commit can sound scary, but it comes down to **one question** and **three commands**. The question is: have you pushed the commit yet? I'll walk you through reset, revert, and the safety net that gets you unstuck when you thought you lost everything.
+
+<div class="video-embed">
+<iframe src="https://www.youtube.com/embed/hRNHGHWrNNA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+## The mental model
+
+A commit is a snapshot of your project at a moment in time. `HEAD` is just a pointer to the snapshot you are currently on. When people say "undo a commit," they usually mean one of three things:
+
+1. They want to undo a commit but **keep the code**.
+2. They want the commit **and** the changes gone entirely.
+3. The changes are already shared with the team, but they need to reverse it **safely**.
+
+Those are three different jobs, and using the wrong tool can lead to conflicts and messy history. So before you touch anything, ask: **Have I pushed the commit I want to undo yet?**
+
+## Still local? Use reset
+
+If the changes are still only on your machine, use `git reset`. Reset moves `HEAD` back, and it has three flavors that decide what happens to your code.
+
+### Soft — undo the commit, keep everything staged
+
+You committed too early, but the code is good. You want to uncommit and keep everything staged, ready to recommit:
+
+```bash
+git reset --soft HEAD~1
+```
+
+The commit is gone, but the work isn't. `HEAD~1` means one commit back. Change the `1` to undo more commits at once.
+
+### Default (mixed) — undo the commit, unstage the changes
+
+Same idea, but your changes go back to unstaged so you can edit before you re-commit:
+
+```bash
+git reset HEAD~1
+```
+
+Files are untouched. You only undid the commit and the staging.
+
+### Hard — throw the commit and the changes away
+
+This is the dangerous one. You want the commit **and** the changes gone:
+
+```bash
+git reset --hard HEAD~1
+```
+
+Only reach for `--hard` when you are sure, because it is the one people regret the most. Even then, you can often still recover — more on that below.
+
+**Summary**
+
+| Flavor | Commit | Staging | Working tree |
+|--------|--------|---------|--------------|
+| `--soft` | removed | kept | kept |
+| (default) | removed | unstaged | kept |
+| `--hard` | removed | cleared | discarded |
+
+## Already pushed? Use revert
+
+If you already pushed the commit, or it is on a branch your teammates pulled, **don't reset**. Rewriting history that other people already have makes a mess for everyone. Use `git revert` instead.
+
+Revert does not delete anything. It creates a **brand new commit** that is exactly the opposite of the one you want to undo. History stays intact, everyone stays in sync, and the bad change is gone.
+
+```bash
+git revert <commit-hash>
+```
+
+You can revert any commit, not just the last one. Git writes the inverse operations and opens a commit message for you. If you added a file in the bad commit, the revert removes that file. The history is there, but it is undone.
+
+**Rule of thumb:** if you already pushed it → revert. If things are still local → reset.
+
+## The safety net: reflog
+
+Say you ran a hard reset by mistake and it looks like your commit and your work vanished. Almost certainly it is still there. Git keeps a log of everywhere `HEAD` has been, called the **reflog**.
+
+```bash
+git reflog
+```
+
+You see a list of every recent move, each with its own hash. Find the state you want to go back to, copy the hash, and reset to it:
+
+```bash
+git reset --hard <hash-from-reflog>
+```
+
+You are back like it never happened. Before you panic about lost commits, check the reflog. Nine times out of ten, the work is sitting right there.
+
+The one thing reflog cannot save you from is deleting the `.git` folder itself — so don't do that.
+
+I wrote a deeper dive on this: [Recovering lost commits with git reflog](/recovering-lost-commits-with-git-reflog/).
+
+## Bonus: amend
+
+Sometimes you don't want to undo a commit — you just want to fix it (wrong message, or you forgot a file).
+
+```bash
+git commit --amend -m "Better message"
+# or stage a forgotten file first, then:
+git commit --amend --no-edit
+```
+
+Remember: amend also rewrites history, so the push-or-not-push rule still applies.
+
+## Cheat sheet
+
+1. **Have I pushed the commit yet?**
+2. **No** → `reset`
+   - `--soft` to keep it staged
+   - default to keep it unstaged
+   - `--hard` to throw everything away
+3. **Yes** → `revert` (safe reverse with a new commit)
+4. **Looks lost?** → `git reflog`, then `git reset --hard <hash>`
+5. **Just need a small fix on the last local commit?** → `git commit --amend`
+
+Those are most of the commands you ever need to fix or undo a commit in Git.
+
+If this made Git feel less scary, the next deep-dive is about the git commands you actually use every day. In the meantime, tell me in the comments: what's the worst Git mistake you ever had to undo?

--- a/_posts/2026-07-30-undo-anything-in-git-reset-vs-revert.md
+++ b/_posts/2026-07-30-undo-anything-in-git-reset-vs-revert.md
@@ -25,9 +25,9 @@ Your coding assistant just made five commits, and one of them broke everything. 
 
 Undoing a commit can sound scary, but it comes down to **one question** and **three commands**. The question is: have you pushed the commit yet? I'll walk you through reset, revert, and the safety net that gets you unstuck when you thought you lost everything.
 
-<div class="video-embed">
-<iframe src="https://www.youtube.com/embed/hRNHGHWrNNA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div>
+<center>
+<iframe style="max-width:100%; width:560px; aspect-ratio:16/9; height:auto;" src="https://www.youtube.com/embed/hRNHGHWrNNA" title="How to Undo Commits in Git" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</center>
 
 ## The mental model
 

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -352,28 +352,3 @@ pre.mermaid + .copy-button,
 pre.mermaid .copy-button {
     display: none !important;
 }
-
-/* Responsive YouTube embeds — prevents horizontal scroll on mobile */
-.video-embed {
-    position: relative;
-    width: 100%;
-    max-width: 560px;
-    margin: 1.5em auto;
-    aspect-ratio: 16 / 9;
-}
-
-.video-embed iframe {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    border: 0;
-}
-
-/* Fallback for any leftover fixed-width iframes (e.g. width="560") */
-.post iframe,
-article iframe,
-.panel iframe,
-center > iframe {
-    max-width: 100%;
-}

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -352,3 +352,28 @@ pre.mermaid + .copy-button,
 pre.mermaid .copy-button {
     display: none !important;
 }
+
+/* Responsive YouTube embeds — prevents horizontal scroll on mobile */
+.video-embed {
+    position: relative;
+    width: 100%;
+    max-width: 560px;
+    margin: 1.5em auto;
+    aspect-ratio: 16 / 9;
+}
+
+.video-embed iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
+/* Fallback for any leftover fixed-width iframes (e.g. width="560") */
+.post iframe,
+article iframe,
+.panel iframe,
+center > iframe {
+    max-width: 100%;
+}


### PR DESCRIPTION
## Summary
Adds four short-form video posts for the July 2026 Git tip YouTube Shorts, following the same pattern as the existing June 2026 stash shorts (`type: video`, `hidden: true`, YouTube embed + link to the deeper pro-tip post).

| Short | Date | File | Links to |
|-------|------|------|----------|
| rebase --onto | 2026-07-14 | `_posts/2026-07-14-git-rebase-onto-short.md` | [Fixing the branch source…](/fixing-the-branch-source-with-git-rebase/) |
| stash stack | 2026-07-16 | `_posts/2026-07-16-git-stash-stack-short.md` | [Using git stash…](/using-git-stash-and-git-stash-pop/) |
| empty commit | 2026-07-21 | `_posts/2026-07-21-git-empty-commit-short.md` | [Using empty commits…](/force-rebuild-jekyll-en/) |
| stash drop | 2026-07-23 | `_posts/2026-07-23-git-stash-drop-short.md` | [Why git stash drop…](/why-the-git-stash-drop-is-useful/) |

## Notes
- Dates match when the Shorts went live (from the corresponding X posts).
- Content is adapted directly from the provided transcripts + the existing longer posts.
- Ready for the next batch of 9 whenever you have the transcripts/links.