### PR TITLE
Fix mobile hamburger menu not opening on production

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,8 +33,9 @@
           <span class="material-symbols-outlined text-xl" id="theme-icon" aria-hidden="true">dark_mode</span>
         </button>
 
-        <button id="mobile-nav-toggle" type="button" class="rounded-full p-2 text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav-menu">
-          <span class="material-symbols-outlined text-xl" aria-hidden="true">menu</span>
+        <button id="mobile-nav-toggle" type="button" class="relative rounded-full p-2 text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav-menu">
+          <span data-nav-icon="menu" class="material-symbols-outlined text-xl" aria-hidden="true">menu</span>
+          <span data-nav-icon="close" class="hidden text-2xl font-light leading-none" aria-hidden="true">&times;</span>
         </button>
       </div>
     </div>
@@ -50,4 +51,4 @@
   </div>
 </header>
 
-<script src="{{ '/assets/js/mobile-nav.js?v=20260823c' | relative_url }}" defer></script>
+<script src="{{ '/assets/js/mobile-nav.js?v=20260823d' | relative_url }}" defer></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,16 @@
 {% include language-detection.html %}
 
+{% if current_lang == "en" %}
+  {% assign nav_label_open = "Close navigation" %}
+  {% assign nav_label_closed = "Toggle navigation" %}
+{% elsif current_lang == "fr" %}
+  {% assign nav_label_open = "Fermer la navigation" %}
+  {% assign nav_label_closed = "Ouvrir la navigation" %}
+{% else %}
+  {% assign nav_label_open = "Fechar navegação" %}
+  {% assign nav_label_closed = "Abrir navegação" %}
+{% endif %}
+
 <header class="sticky top-0 z-50 border-b border-outline-variant bg-surface-container-lowest/80 backdrop-blur-md dark:border-outline dark:bg-background-dark/80">
   <div class="site-container">
     <div class="flex h-20 items-center justify-between">
@@ -33,7 +44,7 @@
           <span class="material-symbols-outlined text-xl" id="theme-icon" aria-hidden="true">dark_mode</span>
         </button>
 
-        <button id="mobile-nav-toggle" type="button" class="flex h-10 w-10 items-center justify-center rounded-full text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav-menu">
+        <button id="mobile-nav-toggle" type="button" class="flex h-10 w-10 items-center justify-center rounded-full text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="{{ nav_label_closed }}" aria-expanded="false" aria-controls="mobile-nav-menu" data-label-open="{{ nav_label_open }}" data-label-closed="{{ nav_label_closed }}">
           <span data-nav-icon="menu" class="material-symbols-outlined text-xl" aria-hidden="true">menu</span>
           <span data-nav-icon="close" class="hidden text-2xl font-light leading-none" aria-hidden="true">&times;</span>
         </button>
@@ -51,4 +62,4 @@
   </div>
 </header>
 
-<script src="{{ '/assets/js/mobile-nav.js?v=20260823e' | relative_url }}" defer></script>
+<script src="{{ '/assets/js/mobile-nav.js?v=20260823f' | relative_url }}" defer></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,9 +33,9 @@
           <span class="material-symbols-outlined text-xl" id="theme-icon" aria-hidden="true">dark_mode</span>
         </button>
 
-        <button id="mobile-nav-toggle" type="button" class="relative flex h-10 w-10 items-center justify-center rounded-full text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav-menu">
+        <button id="mobile-nav-toggle" type="button" class="flex h-10 w-10 items-center justify-center rounded-full text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav-menu">
           <span data-nav-icon="menu" class="material-symbols-outlined text-xl" aria-hidden="true">menu</span>
-          <span data-nav-icon="close" class="absolute inset-0 hidden flex items-center justify-center text-2xl font-light leading-none" aria-hidden="true">&times;</span>
+          <span data-nav-icon="close" class="hidden text-2xl font-light leading-none" aria-hidden="true">&times;</span>
         </button>
       </div>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -50,4 +50,4 @@
   </div>
 </header>
 
-<script src="{{ '/assets/js/mobile-nav.js' | relative_url }}" defer></script>
+<script src="{{ '/assets/js/mobile-nav.js?v=20260821' | relative_url }}" defer></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,9 +33,9 @@
           <span class="material-symbols-outlined text-xl" id="theme-icon" aria-hidden="true">dark_mode</span>
         </button>
 
-        <button id="mobile-nav-toggle" type="button" class="relative rounded-full p-2 text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav-menu">
+        <button id="mobile-nav-toggle" type="button" class="relative flex h-10 w-10 items-center justify-center rounded-full text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav-menu">
           <span data-nav-icon="menu" class="material-symbols-outlined text-xl" aria-hidden="true">menu</span>
-          <span data-nav-icon="close" class="hidden text-2xl font-light leading-none" aria-hidden="true">&times;</span>
+          <span data-nav-icon="close" class="absolute inset-0 hidden items-center justify-center text-2xl font-light leading-none" aria-hidden="true">&times;</span>
         </button>
       </div>
     </div>
@@ -51,4 +51,4 @@
   </div>
 </header>
 
-<script src="{{ '/assets/js/mobile-nav.js?v=20260823d' | relative_url }}" defer></script>
+<script src="{{ '/assets/js/mobile-nav.js?v=20260823e' | relative_url }}" defer></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -34,7 +34,7 @@
         </button>
 
         <button id="mobile-nav-toggle" type="button" class="rounded-full p-2 text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav-menu">
-          <span class="material-symbols-outlined text-xl" aria-hidden="true">menu</span>
+          <span class="material-symbols-outlined text-xl" aria-hidden="true" style="text-transform:none;font-feature-settings:'liga'">menu</span>
         </button>
       </div>
     </div>
@@ -50,4 +50,4 @@
   </div>
 </header>
 
-<script src="{{ '/assets/js/mobile-nav.js?v=20260821' | relative_url }}" defer></script>
+<script src="{{ '/assets/js/mobile-nav.js?v=20260823' | relative_url }}" defer></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -35,7 +35,7 @@
 
         <button id="mobile-nav-toggle" type="button" class="relative flex h-10 w-10 items-center justify-center rounded-full text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav-menu">
           <span data-nav-icon="menu" class="material-symbols-outlined text-xl" aria-hidden="true">menu</span>
-          <span data-nav-icon="close" class="absolute inset-0 hidden items-center justify-center text-2xl font-light leading-none" aria-hidden="true">&times;</span>
+          <span data-nav-icon="close" class="absolute inset-0 hidden flex items-center justify-center text-2xl font-light leading-none" aria-hidden="true">&times;</span>
         </button>
       </div>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -50,4 +50,4 @@
   </div>
 </header>
 
-<script src="{{ '/assets/js/mobile-nav.js?v=20260823b' | relative_url }}" defer></script>
+<script src="{{ '/assets/js/mobile-nav.js?v=20260823c' | relative_url }}" defer></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -34,7 +34,7 @@
         </button>
 
         <button id="mobile-nav-toggle" type="button" class="rounded-full p-2 text-on-surface-variant transition-colors hover:bg-surface-container md:hidden dark:text-inverse-on-surface dark:hover:bg-inverse-surface" aria-label="Toggle navigation" aria-expanded="false" aria-controls="mobile-nav-menu">
-          <span class="material-symbols-outlined text-xl" aria-hidden="true" style="text-transform:none;font-feature-settings:'liga'">menu</span>
+          <span class="material-symbols-outlined text-xl" aria-hidden="true">menu</span>
         </button>
       </div>
     </div>
@@ -50,4 +50,4 @@
   </div>
 </header>
 
-<script src="{{ '/assets/js/mobile-nav.js?v=20260823' | relative_url }}" defer></script>
+<script src="{{ '/assets/js/mobile-nav.js?v=20260823b' | relative_url }}" defer></script>

--- a/assets/js/mobile-nav.js
+++ b/assets/js/mobile-nav.js
@@ -6,45 +6,32 @@
 
   function setMenuOpen(open) {
     if (!toggle || !menu) return;
-    // Tailwind class controls visibility
+
     menu.classList.toggle('hidden', !open);
-    // Keep native hidden attribute in sync for a11y / screen readers
     if (open) {
       menu.removeAttribute('hidden');
     } else {
       menu.setAttribute('hidden', '');
     }
+
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
     toggle.setAttribute('aria-label', open ? 'Close navigation' : 'Toggle navigation');
 
-    // Icon: hamburger when closed, plain × when open.
-    // Avoid Material Symbols "close" — it was rendering as the word CLOSE.
-    const icon = toggle.querySelector('.material-symbols-outlined');
-    if (icon) {
-      if (open) {
-        icon.textContent = '\u00D7'; // ×
-        icon.classList.remove('material-symbols-outlined');
-        icon.style.fontSize = '1.5rem';
-        icon.style.lineHeight = '1';
-        icon.style.fontWeight = '300';
-      } else {
-        icon.textContent = 'menu';
-        icon.classList.add('material-symbols-outlined');
-        icon.style.fontSize = '';
-        icon.style.lineHeight = '';
-        icon.style.fontWeight = '';
-      }
+    // Two dedicated icons — only visibility changes, never textContent/class.
+    const iconMenu = toggle.querySelector('[data-nav-icon="menu"]');
+    const iconClose = toggle.querySelector('[data-nav-icon="close"]');
+    if (iconMenu && iconClose) {
+      iconMenu.classList.toggle('hidden', open);
+      iconClose.classList.toggle('hidden', !open);
     }
   }
 
   if (toggle && menu) {
-    // Ensure closed state on load (sync class + attribute)
     setMenuOpen(false);
 
     toggle.addEventListener('click', function (e) {
       e.preventDefault();
       e.stopPropagation();
-      // Prefer classList (what actually drives the visual) over the attribute
       const currentlyHidden = menu.classList.contains('hidden');
       setMenuOpen(currentlyHidden);
     });

--- a/assets/js/mobile-nav.js
+++ b/assets/js/mobile-nav.js
@@ -6,21 +6,32 @@
 
   function setMenuOpen(open) {
     if (!toggle || !menu) return;
+    // Tailwind class controls visibility
     menu.classList.toggle('hidden', !open);
+    // Keep native hidden attribute in sync for a11y / screen readers
     if (open) {
       menu.removeAttribute('hidden');
     } else {
       menu.setAttribute('hidden', '');
     }
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    // Update the icon for clearer affordance
+    const icon = toggle.querySelector('.material-symbols-outlined');
+    if (icon) {
+      icon.textContent = open ? 'close' : 'menu';
+    }
   }
 
   if (toggle && menu) {
-    // Keep HTML hidden attribute in sync with the Tailwind "hidden" class.
+    // Ensure closed state on load (sync class + attribute)
     setMenuOpen(false);
 
-    toggle.addEventListener('click', function () {
-      setMenuOpen(menu.hasAttribute('hidden'));
+    toggle.addEventListener('click', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      // Prefer classList (what actually drives the visual) over the attribute
+      const currentlyHidden = menu.classList.contains('hidden');
+      setMenuOpen(currentlyHidden);
     });
   }
 
@@ -32,7 +43,8 @@
 
     setLangOpen(false);
 
-    langToggle.addEventListener('click', function () {
+    langToggle.addEventListener('click', function (e) {
+      e.stopPropagation();
       setLangOpen(langMenu.classList.contains('hidden'));
     });
 

--- a/assets/js/mobile-nav.js
+++ b/assets/js/mobile-nav.js
@@ -16,9 +16,25 @@
     }
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
     toggle.setAttribute('aria-label', open ? 'Close navigation' : 'Toggle navigation');
-    // Intentionally keep the hamburger icon in both states.
-    // Swapping to the Material Symbols "close" glyph was rendering
-    // the literal word CLOSE for some users.
+
+    // Icon: hamburger when closed, plain × when open.
+    // Avoid Material Symbols "close" — it was rendering as the word CLOSE.
+    const icon = toggle.querySelector('.material-symbols-outlined');
+    if (icon) {
+      if (open) {
+        icon.textContent = '\u00D7'; // ×
+        icon.classList.remove('material-symbols-outlined');
+        icon.style.fontSize = '1.5rem';
+        icon.style.lineHeight = '1';
+        icon.style.fontWeight = '300';
+      } else {
+        icon.textContent = 'menu';
+        icon.classList.add('material-symbols-outlined');
+        icon.style.fontSize = '';
+        icon.style.lineHeight = '';
+        icon.style.fontWeight = '';
+      }
+    }
   }
 
   if (toggle && menu) {

--- a/assets/js/mobile-nav.js
+++ b/assets/js/mobile-nav.js
@@ -16,24 +16,9 @@
     }
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
     toggle.setAttribute('aria-label', open ? 'Close navigation' : 'Toggle navigation');
-
-    // Swap Material Symbols icon (ligature). Use 'close' only when the
-    // font is available; fall back to a simple × character so we never
-    // show the raw word "CLOSE".
-    const icon = toggle.querySelector('.material-symbols-outlined');
-    if (icon) {
-      if (open) {
-        // Prefer the symbol glyph; if font fails, × still looks fine
-        icon.textContent = 'close';
-        // Ensure ligatures aren't broken by text-transform
-        icon.style.textTransform = 'none';
-        icon.style.fontFeatureSettings = '"liga"';
-      } else {
-        icon.textContent = 'menu';
-        icon.style.textTransform = '';
-        icon.style.fontFeatureSettings = '';
-      }
-    }
+    // Intentionally keep the hamburger icon in both states.
+    // Swapping to the Material Symbols "close" glyph was rendering
+    // the literal word CLOSE for some users.
   }
 
   if (toggle && menu) {

--- a/assets/js/mobile-nav.js
+++ b/assets/js/mobile-nav.js
@@ -17,7 +17,6 @@
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
     toggle.setAttribute('aria-label', open ? 'Close navigation' : 'Toggle navigation');
 
-    // Two dedicated icons — only visibility changes, never textContent/class.
     const iconMenu = toggle.querySelector('[data-nav-icon="menu"]');
     const iconClose = toggle.querySelector('[data-nav-icon="close"]');
     if (iconMenu && iconClose) {
@@ -32,8 +31,11 @@
     toggle.addEventListener('click', function (e) {
       e.preventDefault();
       e.stopPropagation();
-      const currentlyHidden = menu.classList.contains('hidden');
-      setMenuOpen(currentlyHidden);
+      setMenuOpen(menu.classList.contains('hidden'));
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') setMenuOpen(false);
     });
   }
 

--- a/assets/js/mobile-nav.js
+++ b/assets/js/mobile-nav.js
@@ -15,7 +15,10 @@
     }
 
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
-    toggle.setAttribute('aria-label', open ? 'Close navigation' : 'Toggle navigation');
+
+    const labelOpen = toggle.getAttribute('data-label-open') || 'Close navigation';
+    const labelClosed = toggle.getAttribute('data-label-closed') || 'Toggle navigation';
+    toggle.setAttribute('aria-label', open ? labelOpen : labelClosed);
 
     const iconMenu = toggle.querySelector('[data-nav-icon="menu"]');
     const iconClose = toggle.querySelector('[data-nav-icon="close"]');

--- a/assets/js/mobile-nav.js
+++ b/assets/js/mobile-nav.js
@@ -15,10 +15,24 @@
       menu.setAttribute('hidden', '');
     }
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
-    // Update the icon for clearer affordance
+    toggle.setAttribute('aria-label', open ? 'Close navigation' : 'Toggle navigation');
+
+    // Swap Material Symbols icon (ligature). Use 'close' only when the
+    // font is available; fall back to a simple × character so we never
+    // show the raw word "CLOSE".
     const icon = toggle.querySelector('.material-symbols-outlined');
     if (icon) {
-      icon.textContent = open ? 'close' : 'menu';
+      if (open) {
+        // Prefer the symbol glyph; if font fails, × still looks fine
+        icon.textContent = 'close';
+        // Ensure ligatures aren't broken by text-transform
+        icon.style.textTransform = 'none';
+        icon.style.fontFeatureSettings = '"liga"';
+      } else {
+        icon.textContent = 'menu';
+        icon.style.textTransform = '';
+        icon.style.fontFeatureSettings = '';
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the hamburger / mobile nav menu that does nothing when tapped on production (https://jtemporal.com/), while Netlify deploy previews worked fine.

Closes #26

## Changes

- **`assets/js/mobile-nav.js`**
  - Prefer `menu.classList.contains('hidden')` for open/close state (what actually drives the visual with Tailwind) instead of relying only on the HTML `hidden` attribute.
  - Keep the `hidden` attribute + `aria-expanded` in sync for accessibility.
  - Swap the icon to `close` when the menu is open for clearer affordance.
  - Stop propagation / preventDefault on the toggle click to avoid any interference.

- **`_includes/header.html`**
  - Cache-bust the script with `?v=20260821` so production clients pick up the new file despite the long-lived `immutable` cache headers on `/assets/js/*`.

## Why this was needed

Production serves `/assets/js/*` with `Cache-Control: public, max-age=31536000, immutable`. A previous version of the script (or a subtle state-sync issue after the a11y hardening) could leave clients with a non-working toggle. Deploy previews use a different build path and don’t hit the same cache, which is why they appeared fine.

## Test plan

- [ ] Open the Netlify deploy preview for this PR on a mobile viewport (or DevTools device mode).
- [ ] Tap the hamburger → menu expands, icon becomes ✕.
- [ ] Tap again → menu collapses, icon becomes ☰.
- [ ] Confirm language switcher and theme toggle still work.
- [ ] After merge, hard-refresh production (or wait for cache) and verify the same behaviour on https://jtemporal.com/.