### PR TITLE
Serve llms.txt markdown from the site instead of GitHub raw

### DIFF
--- a/_plugins/markdown_export.rb
+++ b/_plugins/markdown_export.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Writes a Markdown copy of each post, talk, and video next to its HTML URL
+# so llms.txt can point at first-party files instead of GitHub raw.
+#
+# /the-slug/  ->  /the-slug.md
+# /en/050/    ->  /en/050.md
+
+module Jekyll
+  class MarkdownExportGenerator < Generator
+    safe true
+    priority :low
+
+    TYPES = %w[post talk video].freeze
+
+    def generate(site)
+      site.posts.docs.each do |post|
+        next unless TYPES.include?(post.data['type'])
+
+        relpath = MarkdownExportFile.relpath_for(post)
+        next if relpath.nil?
+
+        post.data['markdown_path'] = "/#{relpath}"
+        site.static_files << MarkdownExportFile.new(site, post, relpath)
+      end
+    end
+  end
+
+  class MarkdownExportFile < StaticFile
+    def self.relpath_for(post)
+      segments = post.url.to_s.split('/').reject(&:empty?)
+      return if segments.empty?
+
+      "#{segments.join('/')}.md"
+    end
+
+    def initialize(site, post, relpath)
+      @source_path = File.expand_path(post.path)
+      dir = File.dirname(relpath)
+      dir = '' if dir == '.'
+      super(site, site.source, dir, File.basename(relpath))
+    end
+
+    def path
+      @source_path
+    end
+  end
+end

--- a/llms.txt
+++ b/llms.txt
@@ -42,21 +42,21 @@ My socials accounts:
 
 ## Talks
 
-Talks I've given in the past. The links below take you to the raw Markdown content.
+Talks I've given in the past. The links below take you to the Markdown source.
 
-{% for post in site.posts %}{% if post.type == "talk" %}- [{{ post.title }}](https://raw.githubusercontent.com/jtemporal/jtemporal.github.io/refs/heads/main/{{ post.path }})
+{% for post in site.posts %}{% if post.type == "talk" %}- [{{ post.title }}]({{ post.markdown_path | absolute_url }})
 {% endif %}{% endfor %}
 
 ## Videos
 
-Short video transcripts. The links below take you to the raw Markdown content.
+Short video transcripts. The links below take you to the Markdown source.
 
-{% for post in site.posts %}{% if post.type == "video" %}- [{{ post.title }}](https://raw.githubusercontent.com/jtemporal/jtemporal.github.io/refs/heads/main/{{ post.path }})
+{% for post in site.posts %}{% if post.type == "video" %}- [{{ post.title }}]({{ post.markdown_path | absolute_url }})
 {% endif %}{% endfor %}
 
 ## All posts
 
-All of my posts on the blog jtemporal.com. The links below take you to the raw Markdown content.
+All of my posts on the blog jtemporal.com. The links below take you to the Markdown source.
 
-{% for post in site.posts %}{% if post.type == "post" %}- [{{ post.title }}](https://raw.githubusercontent.com/jtemporal/jtemporal.github.io/refs/heads/main/{{ post.path }})
+{% for post in site.posts %}{% if post.type == "post" %}- [{{ post.title }}]({{ post.markdown_path | absolute_url }})
 {% endif %}{% endfor %}

--- a/netlify.toml
+++ b/netlify.toml
@@ -42,6 +42,19 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     X-XSS-Protection = "1; mode=block"
 
+# LLM markdown copies: not for human indexes, served as markdown
+[[headers]]
+  for = "/*.md"
+  [headers.values]
+    Content-Type = "text/markdown; charset=utf-8"
+    X-Robots-Tag = "noindex, nofollow"
+
+[[headers]]
+  for = "/*/*.md"
+  [headers.values]
+    Content-Type = "text/markdown; charset=utf-8"
+    X-Robots-Tag = "noindex, nofollow"
+
 # HTML/pages: short revalidate cache. Clean URLs (no .html) need an explicit rule.
 [[headers]]
   for = "*.html"


### PR DESCRIPTION
## Summary

`llms.txt` currently sends agents to GitHub raw URLs, so those fetches never hit jtemporal.com. This serves a first-party Markdown copy of each post, talk, and video at `/<slug>.md` and points `llms.txt` there.

- Plugin writes `/<slug>.md` from the post source at build time
- HTML pages stay at `/<slug>/` for human readers
- Markdown copies are left out of `sitemap.xml` and site nav
- Netlify serves them as `text/markdown` with `X-Robots-Tag: noindex, nofollow`

## Test plan

- [ ] Preview `llms.txt` and confirm links are `https://<deploy>/<slug>.md`, not GitHub raw
- [ ] Open a markdown URL (e.g. `/gitkeep-track-empty-folders-short.md`) and confirm raw source with front matter
- [ ] Open the matching HTML URL (`/<slug>/`) and confirm the human page is unchanged
- [ ] Check `sitemap.xml` has no `.md` entries
- [ ] `curl -I` a `.md` URL on the Netlify deploy and confirm `Content-Type: text/markdown` and `X-Robots-Tag: noindex, nofollow`