### PR TITLE
Document -short vs -video URL suffixes for hidden video posts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent instructions — jtemporal.github.io
 
-Canonical workflow for AI agents working in this repo. **Read this file first** for hidden YouTube short posts, git worktree conventions, and OG social card generation.
+Canonical workflow for AI agents working in this repo. **Read this file first** for hidden YouTube video posts (shorts and long-form), git worktree conventions, and OG social card generation.
 
 Also referenced from:
 - `CLAUDE.md` (Claude / Claude Code)
@@ -33,9 +33,18 @@ git commit -m "Your commit message" --trailer "Co-authored-by: Grok <grok@x.ai>"
 
 You can also put the trailer in the commit message body (after a blank line). This makes the commit appear as a joint effort between the author and the agent.
 
-## Hidden YouTube short posts
+## Hidden video posts
 
 These posts syndicate video transcripts to Medium and/or [dev.to](https://dev.to). They are **not** meant to appear on the public blog index.
+
+There are two kinds. The URL suffix must match the kind:
+
+| Kind | Filename | URL | `short` tag |
+|------|----------|-----|-------------|
+| YouTube short | `_posts/YYYY-MM-DD-<slug>-short.md` | `/<slug>-short/` | yes |
+| Long-form video | `_posts/YYYY-MM-DD-<slug>-video.md` | `/<slug>-video/` | no |
+
+Do not put `-short` on a long-form video, and do not put `-video` on a short. Already-published long-form URLs stay as they are (for example `/undo-anything-in-git-reset-vs-revert/` has no suffix). Only **new** long-form video posts get `-video`.
 
 ### Approval gates (strict)
 
@@ -53,11 +62,13 @@ git fetch origin
 git worktree add ../jtemporal.github.io-hidden-post-<slug> -b hidden-post-<slug> origin/main
 ```
 
-| Item | Pattern | Example |
-|------|---------|---------|
-| Worktree path | `../jtemporal.github.io-hidden-post-<slug>` | `jtemporal.github.io-hidden-post-gitkeep` |
-| Branch | `hidden-post-<slug>` | `hidden-post-gitkeep` |
-| Post file | `_posts/YYYY-MM-DD-<slug>-short.md` | `_posts/2026-06-25-gitkeep-track-empty-folders-short.md` |
+| Item | Pattern | Example (short) | Example (long-form) |
+|------|---------|-----------------|---------------------|
+| Worktree path | `../jtemporal.github.io-hidden-post-<slug>` | `jtemporal.github.io-hidden-post-gitkeep` | `jtemporal.github.io-hidden-post-my-yarn-stash-ai-lessons` |
+| Branch | `hidden-post-<slug>` | `hidden-post-gitkeep` | `hidden-post-my-yarn-stash-ai-lessons` |
+| Post file | `_posts/YYYY-MM-DD-<slug>-short.md` or `-video.md` | `_posts/2026-06-25-gitkeep-track-empty-folders-short.md` | `_posts/2026-08-26-my-yarn-stash-ai-lessons-video.md` |
+
+The worktree/branch slug is the topic name **without** `-short` or `-video`. Those suffixes belong only on the markdown filename (and therefore the public URL).
 
 Before pushing, rebase onto latest `main` if other PRs merged:
 
@@ -92,7 +103,7 @@ Verify cleanup with `git worktree list` — only active worktrees should remain.
 
 Multiple posts can be built in parallel — each in its own worktree/branch. Keep everything local until approved. Only one Jekyll server should bind to port 4000 at a time; use `--port 4001` etc. for simultaneous previews.
 
-### Frontmatter template
+### Frontmatter template (short)
 
 ```yaml
 ---
@@ -118,11 +129,13 @@ posts_list:
 ---
 ```
 
+For a **long-form** video, use the same fields except: filename ends in `-video.md`, omit the `short` tag, and use `miscellaneous.webp` when the topic is not git.
+
 ### Post body conventions
 
 - Polish the transcript lightly: fix grammar, keep the author's voice and emoji usage.
 - Link to a related full blog post instead of placeholder text.
-- YouTube embed (extract ID from `https://youtube.com/shorts/<ID>` or `https://www.youtube.com/shorts/<ID>`):
+- YouTube embed (extract ID from `https://youtube.com/shorts/<ID>`, `https://www.youtube.com/shorts/<ID>`, `https://youtu.be/<ID>`, or `https://www.youtube.com/watch?v=<ID>`):
 
 ```html
 <center>
@@ -130,7 +143,7 @@ posts_list:
 </center>
 ```
 
-- End with a short follow CTA (match tone of existing shorts).
+- End with a short follow CTA (match tone of existing shorts or the long-form undo/yarn-stash video posts).
 - Save a copy of the draft in `/Users/jesstemporal/projects/youtube/shorts-hidden-posts/` when that path is available.
 
 ### Preview URL
@@ -146,15 +159,17 @@ The slug comes from the filename (without date prefix and `.md`).
 Generate the OG social card first (see **OG social cards** below), then commit and open the PR:
 
 ```bash
-npm run og:generate -- _posts/YYYY-MM-DD-<slug>-short.md
-git add _posts/YYYY-MM-DD-<slug>-short.md images/og/<slug>.png
+npm run og:generate -- _posts/YYYY-MM-DD-<slug>-short.md   # or -video.md
+git add _posts/YYYY-MM-DD-<slug>-short.md images/og/<filename-slug>.png
 git commit -m "Add hidden <topic> short video transcript post" --trailer "Co-authored-by: Grok <grok@x.ai>"
 git push -u origin hidden-post-<slug>
 gh pr create --repo jtemporal/jtemporal.github.io \
   --head hidden-post-<slug> --base main \
   --title "Add hidden <topic> short video transcript post" \
-  --body "## Summary\n\nAdds a hidden type: video post for Medium syndication.\n\n- Post: _posts/...\n- YouTube: <shorts URL>"
+  --body "## Summary\n\nAdds a hidden type: video post for Medium syndication.\n\n- Post: _posts/...\n- YouTube: <video URL>"
 ```
+
+Use `-video.md` / `images/og/<slug>-video.png` / a “long-form video” title when the post is not a short.
 
 ## OG social cards (required for every new post, video, and talk)
 
@@ -181,7 +196,8 @@ Set `type` and `tags` correctly so the card picks the right theme:
 | Content | `type` | Tags / `image` hint |
 |---------|--------|---------------------|
 | Blog post | `post` (or omit) | Category tag (`pro_tip`, `tutorial`, `hacktoberfest`, etc.) |
-| YouTube short | `video` | Topic + category tags; `image: /images/covers/pro_tip.webp` for git tips |
+| YouTube short | `video` | Topic + category tags + `short`; `image: /images/covers/pro_tip.webp` for git tips |
+| Long-form video | `video` | Topic + category tags, **no** `short`; `image: /images/covers/miscellaneous.webp` when it is not a git tip |
 | Talk / podcast | `talk` | `image: /images/covers/podcast.webp` etc.; title/description help classify talk type |
 
 The Jekyll plugin (`_plugins/og_image.rb`) automatically uses `images/og/<slug>.png` as the post's social/featured image when the file exists.
@@ -192,7 +208,7 @@ Always `git add` the generated PNG alongside the markdown file. For bilingual po
 
 ### When to generate
 
-- **Hidden video shorts:** after the author approves the preview, before commit.
+- **Hidden video posts (short or long-form):** after the author approves the preview, before commit.
 - **Regular posts / talks / videos:** before opening the PR.
 - **Never skip** for new content — every slug needs its own `images/og/<slug>.png`.
 
@@ -201,12 +217,14 @@ Always `git add` the generated PNG alongside the markdown file. For bilingual po
 When batching posts, the author will provide per video:
 
 ```
-slug: <short-kebab-name>
+slug: <short-kebab-name>          # no -short / -video suffix; the agent adds it
 date: YYYY-MM-DD
-youtube: https://youtube.com/shorts/<ID>
+youtube: https://youtube.com/shorts/<ID>   # or https://youtu.be/<ID> for long-form
 transcript: <absolute path to .md>
 topic: git | ai | other
 related: <optional comma-separated post slugs>
 ```
+
+Infer short vs long-form from the YouTube URL (`/shorts/` vs `youtu.be` / `watch`) unless the author says otherwise. Filename becomes `<slug>-short.md` or `<slug>-video.md`.
 
 The agent creates worktrees, drafts posts, starts preview, and waits for approval before commit/push.


### PR DESCRIPTION
## Summary

Documents how hidden `type: video` posts should be named, so shorts and long-form videos stay distinct in the URL.

- Shorts keep `-short` (`/<slug>-short/`)
- New long-form videos use `-video` (`/<slug>-video/`)
- Already-published long-form URLs stay as they are (e.g. `/undo-anything-in-git-reset-vs-revert/`)

Worktree/branch slugs stay as the topic name without the suffix. This is docs-only; no posts are added in this PR.

## Test plan

- [ ] Confirm `AGENTS.md` is the only changed file
- [ ] Confirm the short vs long-form table matches the intended convention